### PR TITLE
Fix filtering when get spans from file

### DIFF
--- a/src/python_opentelemetry_access/util/__init__.py
+++ b/src/python_opentelemetry_access/util/__init__.py
@@ -201,14 +201,14 @@ def expect_list(x: JSONLike) -> JSONLikeList:
         raise TypeError(f"Expected list, got {type(x)}")
 
 
-def expect_literal(x: JSONLike) -> JSONLikeLiteral:
+def expect_literal(x: object) -> JSONLikeLiteral:
     if isinstance(x, str) or isinstance(x, int) or isinstance(x, float):
         return x
     else:
         raise TypeError(f"Expected literal, got {type(x)}")
 
 
-def expect_str(x) -> str:
+def expect_str(x: object) -> str:
     if isinstance(x, str):
         return x
     else:
@@ -334,4 +334,22 @@ def normalise_attributes_deep_iter(jobj: JSONLikeDictIter) -> JSONLikeDictIter:
 def normalise_attributes_deep(jobj: JSONLikeDict) -> JSONLikeDict:
     return force_jsonlike_dict_iter(
         normalise_attributes_deep_iter(iter_jsonlike_dict(jobj))
+    )
+
+
+def match_attributes(
+    actual_attributes: JSONLikeDict, expected_attributes: Optional[dict[str, list[str]]]
+) -> bool:
+    if expected_attributes is None:
+        return True
+    
+    normalized_attributes = dict(
+        normalise_attributes_shallow_iter(iter_jsonlike_dict(actual_attributes))
+    )
+    return all(
+        (
+            k in normalized_attributes
+            and str(expect_literal(normalized_attributes[k])) in vs
+        )
+        for k, vs in expected_attributes.items()
     )

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,0 +1,242 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from pytest import mark
+from python_opentelemetry_access import otlpjson, util
+from python_opentelemetry_access.proxy import _filter_span_collection
+
+
+@dataclass
+class Params:
+    expected_spans: list[str]
+    from_time: datetime | None = None
+    to_time: datetime | None = None
+    span_ids: list[tuple[str | None, str | None]] | None = None
+    resource_attributes: dict[str, list[str]] | None = None
+    scope_attributes: dict[str, list[str]] | None = None
+    span_attributes: dict[str, list[str]] | None = None
+
+
+@mark.parametrize(
+    "params",
+    [
+        Params(
+            expected_spans=["res1_scope1_trace1_span1", "res1_scope2_trace1_span1"],
+            resource_attributes={"int_resource_attr": ["100"]},
+            span_attributes={"string_span_attr": ["span string 1"]},
+        ),
+        Params(
+            expected_spans=[
+                "res1_scope1_trace1_span1",
+                "res1_scope1_trace1_span2",
+                "res2_scope1_trace1_span1",
+            ],
+            resource_attributes={
+                "int_resource_attr": ["100", "200"],
+                "string_resource_attr": ["resource string 1", "resource string 2"],
+            },
+            scope_attributes={"string_scope_attr": ["scope string 1"]},
+        ),
+        Params(
+            expected_spans=[],
+            resource_attributes={"string_resource_attr": ["invalid_value"]},
+        ),
+        Params(
+            expected_spans=[],
+            span_attributes={"invalid_attribute": ["span string 2"]},
+        ),
+    ],
+)
+def test_filtering(params: Params) -> None:
+    filtered_spans = _filter_span_collection(
+        otlpjson.loado(_get_spans()).to_reified(),
+        from_time=params.from_time,
+        to_time=params.to_time,
+        span_ids=params.span_ids,
+        resource_attributes=params.resource_attributes,
+        scope_attributes=params.scope_attributes,
+        span_attributes=params.span_attributes,
+    )
+
+    span_ids = set(
+        span.to_reified().span_id for _, _, span in filtered_spans.iter_spans()
+    )
+
+    print(span_ids)
+
+    assert span_ids == set(params.expected_spans)
+
+
+def _get_spans() -> util.JSONLike:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "int_resource_attr", "value": {"intValue": "100"}},
+                        {
+                            "key": "string_resource_attr",
+                            "value": {"stringValue": "resource string 1"},
+                        },
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {
+                            "name": "some_scope",
+                            "attributes": [
+                                {"key": "int_scope_attr", "value": {"intValue": "10"}},
+                                {
+                                    "key": "string_scope_attr",
+                                    "value": {"stringValue": "scope string 1"},
+                                },
+                            ],
+                        },
+                        "spans": [
+                            {
+                                "traceId": "res1_scope1_trace1",
+                                "spanId": "res1_scope1_trace1_span1",
+                                "parentSpanId": "",
+                                "startTimeUnixNano": "1729007194857023153",
+                                "endTimeUnixNano": "1729007194857127603",
+                                "name": "some_span",
+                                "kind": 1,
+                                "status": {},
+                                "attributes": [
+                                    {
+                                        "key": "int_span_attr",
+                                        "value": {"intValue": "1"},
+                                    },
+                                    {
+                                        "key": "string_span_attr",
+                                        "value": {"stringValue": "span string 1"},
+                                    },
+                                ],
+                            },
+                            {
+                                "traceId": "res1_scope1_trace1",
+                                "spanId": "res1_scope1_trace1_span2",
+                                "parentSpanId": "res1_scope1_trace1_span1",
+                                "startTimeUnixNano": "1729007194857023153",
+                                "endTimeUnixNano": "1729007194857127603",
+                                "name": "some_span",
+                                "kind": 1,
+                                "status": {},
+                                "attributes": [
+                                    {
+                                        "key": "int_span_attr",
+                                        "value": {"intValue": "2"},
+                                    },
+                                    {
+                                        "key": "string_span_attr",
+                                        "value": {"stringValue": "span string 2"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "scope": {
+                            "name": "some_scope",
+                            "attributes": [
+                                {"key": "int_scope_attr", "value": {"intValue": "20"}},
+                                {
+                                    "key": "string_scope_attr",
+                                    "value": {"stringValue": "scope string 2"},
+                                },
+                            ],
+                        },
+                        "spans": [
+                            {
+                                "traceId": "res1_scope2_trace1",
+                                "spanId": "res1_scope2_trace1_span1",
+                                "parentSpanId": "",
+                                "startTimeUnixNano": "1729007194857023153",
+                                "endTimeUnixNano": "1729007194857127603",
+                                "name": "some_span",
+                                "kind": 1,
+                                "status": {},
+                                "attributes": [
+                                    {
+                                        "key": "int_span_attr",
+                                        "value": {"intValue": "1"},
+                                    },
+                                    {
+                                        "key": "string_span_attr",
+                                        "value": {"stringValue": "span string 1"},
+                                    },
+                                ],
+                            },
+                            {
+                                "traceId": "res1_scope2_trace1",
+                                "spanId": "res1_scope2_trace1_span2",
+                                "parentSpanId": "res1_scope2_trace1_span1",
+                                "startTimeUnixNano": "1729007194857023153",
+                                "endTimeUnixNano": "1729007194857127603",
+                                "name": "some_span",
+                                "kind": 1,
+                                "status": {},
+                                "attributes": [
+                                    {
+                                        "key": "int_span_attr",
+                                        "value": {"intValue": "2"},
+                                    },
+                                    {
+                                        "key": "string_span_attr",
+                                        "value": {"stringValue": "span string 2"},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "int_resource_attr", "value": {"intValue": "200"}},
+                        {
+                            "key": "string_resource_attr",
+                            "value": {"stringValue": "resource string 2"},
+                        },
+                    ]
+                },
+                "scopeSpans": [
+                    {
+                        "scope": {
+                            "name": "some_scope",
+                            "attributes": [
+                                {"key": "int_scope_attr", "value": {"intValue": "10"}},
+                                {
+                                    "key": "string_scope_attr",
+                                    "value": {"stringValue": "scope string 1"},
+                                },
+                            ],
+                        },
+                        "spans": [
+                            {
+                                "traceId": "res2_scope1_trace1",
+                                "spanId": "res2_scope1_trace1_span1",
+                                "parentSpanId": "",
+                                "startTimeUnixNano": "1729007194857023153",
+                                "endTimeUnixNano": "1729007194857127603",
+                                "name": "some_span",
+                                "kind": 1,
+                                "status": {},
+                                "attributes": [
+                                    {
+                                        "key": "int_span_attr",
+                                        "value": {"intValue": "1"},
+                                    },
+                                    {
+                                        "key": "string_span_attr",
+                                        "value": {"stringValue": "span string 1"},
+                                    },
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        ]
+    }


### PR DESCRIPTION
Previously if I filter resource/scope/span with condition `foo=bar`, and the resource/scope/span didn't have attribute `foo` at all, that resource/scope/span would still be considered to mach this condition.