### PR TITLE
Jp/check using previous data

### DIFF
--- a/example_tests/conftest.py
+++ b/example_tests/conftest.py
@@ -1,0 +1,394 @@
+## Based on:
+## https://github.com/chrisguidry/pytest-opentelemetry/blob/main/src/pytest_opentelemetry/instrumentation.py
+## (under MIT License)
+
+# Copyright (c) 2022 Chris Guidry
+#
+# Copyright (c) 2024 UAB Sensmetry
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import warnings
+
+with warnings.catch_warnings(action="ignore"):
+    import os
+    from typing import Any, Dict, Generator, Optional, Union
+    import pytest
+    from _pytest.config import Config
+    from _pytest.fixtures import FixtureDef, FixtureRequest, SubRequest
+    from _pytest.main import Session
+    from _pytest.nodes import Item, Node
+    from _pytest.reports import TestReport
+    from _pytest.runner import CallInfo
+    from opentelemetry import propagate, trace
+    from opentelemetry.context.context import Context
+    from opentelemetry.sdk.resources import (
+        OTELResourceDetector,
+        Resource,
+        ResourceDetector,
+    )
+    from opentelemetry.semconv.trace import SpanAttributes
+    from opentelemetry.semconv.resource import ResourceAttributes
+    from opentelemetry.trace import Status, StatusCode
+    from opentelemetry_container_distro import (
+        OpenTelemetryContainerConfigurator,
+        OpenTelemetryContainerDistro,
+    )
+    import subprocess
+
+
+from _pytest.config.argparsing import Parser
+
+
+def pytest_addoption(parser: Parser) -> None:
+    group = parser.getgroup("pytest-opentelemetry", "OpenTelemetry for test runs")
+    group.addoption(
+        "--export-traces",
+        action="store_true",
+        default=False,
+        help=(
+            "Enables exporting of OpenTelemetry traces via OTLP, by default to "
+            "http://localhost:4317.  Set the OTEL_EXPORTER_OTLP_ENDPOINT environment "
+            "variable to specify an alternative endpoint."
+        ),
+    )
+    group.addoption(
+        "--trace-parent",
+        action="store",
+        default=None,
+        help=(
+            "Specify a trace parent for this pytest run, in the form of a W3C "
+            "traceparent header, like "
+            "00-1234567890abcdef1234567890abcdef-fedcba0987654321-01.  If a trace "
+            "parent is provided, this test run will appear as a span within that "
+            "trace.  If it is omitted, this test run will start a new trace."
+        ),
+    )
+    group.addoption(
+        "--user-id", action="store", default=None, help="User who runs these tests"
+    )
+
+
+def pytest_configure(config: Config) -> None:
+    if config.pluginmanager.has_plugin("xdist"):
+        config.pluginmanager.register(XdistOpenTelemetryPlugin())
+    else:
+        config.pluginmanager.register(OpenTelemetryPlugin())
+
+
+Attributes = Dict[str, Union[str, bool, int, float]]
+
+tracer = trace.get_tracer("pytest-opentelemetry")
+
+
+class CodebaseResourceDetector(ResourceDetector):
+    """Detects OpenTelemetry Resource attributes for an operating system process,
+    providing the `process.*` attributes"""
+
+    @staticmethod
+    def get_codebase_name() -> str:
+        # TODO: any better ways to guess the name of the codebase?
+        # TODO: look into methods for locating packaging information
+        return os.path.split(os.getcwd())[-1]
+
+    @staticmethod
+    def get_codebase_version() -> str:
+        if not os.path.exists(".git"):
+            return "[unknown: not a git repository]"
+
+        try:
+            version = subprocess.check_output(["git", "rev-parse", "HEAD"])
+        except Exception as exception:  # pylint: disable=broad-except
+            return f"[unknown: {str(exception)}]"
+
+        return version.decode().strip()
+
+    def detect(self) -> Resource:
+        return Resource(
+            {
+                ResourceAttributes.SERVICE_NAME: self.get_codebase_name(),
+                ResourceAttributes.SERVICE_VERSION: self.get_codebase_version(),
+            }
+        )
+
+
+class OpenTelemetryPlugin:
+    """A pytest plugin which produces OpenTelemetry spans around test sessions and
+    individual test runs."""
+
+    @property
+    def session_name(self) -> str:
+        # Lazy initialise session name
+        if not hasattr(self, "_session_name"):
+            self._session_name = os.environ.get("PYTEST_RUN_NAME", "test run")
+        return self._session_name
+
+    @session_name.setter
+    def session_name(self, name: str) -> None:
+        self._session_name = name
+
+    @classmethod
+    def get_trace_parent(cls, config: Config) -> Optional[Context]:
+        if trace_parent := config.getvalue("--trace-parent"):
+            return propagate.extract({"traceparent": trace_parent})
+
+        if trace_parent := os.environ.get("TRACEPARENT"):
+            return propagate.extract({"traceparent": trace_parent})
+
+        return None
+
+    @classmethod
+    def try_force_flush(cls) -> bool:
+        provider = trace.get_tracer_provider()
+
+        # Not all providers (e.g. ProxyTraceProvider) implement force flush
+        if hasattr(provider, "force_flush"):
+            provider.force_flush()
+            return True
+        else:
+            return False
+
+    def pytest_configure(self, config: Config) -> None:
+        self.trace_parent = self.get_trace_parent(config)
+        self.user_id = config.getvalue("--user-id")
+
+        # This can't be tested both ways in one process
+        if config.getoption("--export-traces"):  # pragma: no cover
+            OpenTelemetryContainerDistro().configure()
+
+        configurator = OpenTelemetryContainerConfigurator()
+        configurator.resource_detectors.append(CodebaseResourceDetector())
+        configurator.resource_detectors.append(OTELResourceDetector())
+        configurator.configure()
+
+    def pytest_sessionstart(self, session: Session) -> None:
+        self.session_span = tracer.start_span(
+            self.session_name,
+            context=self.trace_parent,
+            attributes={"pytest.span_type": "run", "user.id": self.user_id},
+        )
+        self.has_error = False
+
+    def pytest_sessionfinish(self, session: Session) -> None:
+        self.session_span.set_status(
+            StatusCode.ERROR if self.has_error else StatusCode.OK
+        )
+
+        self.session_span.end()
+        self.try_force_flush()
+
+    def _attributes_from_item(self, item: Item) -> Dict[str, Union[str, int]]:
+        filepath, line_number, _ = item.location
+        attributes: Dict[str, Union[str, int]] = {
+            SpanAttributes.CODE_FILEPATH: filepath,
+            SpanAttributes.CODE_FUNCTION: item.name,
+            "test.case.name": item.name,
+            "pytest.nodeid": item.nodeid,
+            "pytest.span_type": "test",
+        }
+        # In some cases like tavern, line_number can be 0
+        if line_number:
+            attributes[SpanAttributes.CODE_LINENO] = line_number
+        return attributes
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_protocol(self, item: Item) -> Generator[None, None, None]:
+        context = trace.set_span_in_context(self.session_span)
+        with tracer.start_as_current_span(
+            item.nodeid,
+            attributes=self._attributes_from_item(item),
+            context=context,
+        ):
+            yield
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_setup(self, item: Item) -> Generator[None, None, None]:
+        with tracer.start_as_current_span(
+            f"{item.nodeid}::setup",
+            attributes=self._attributes_from_item(item),
+        ):
+            yield
+
+    def _attributes_from_fixturedef(
+        self, fixturedef: FixtureDef
+    ) -> Dict[str, Union[str, int]]:
+        return {
+            SpanAttributes.CODE_FILEPATH: fixturedef.func.__code__.co_filename,
+            SpanAttributes.CODE_FUNCTION: fixturedef.argname,
+            SpanAttributes.CODE_LINENO: fixturedef.func.__code__.co_firstlineno,
+            "pytest.fixture_scope": fixturedef.scope,
+            "pytest.span_type": "fixture",
+        }
+
+    def _name_from_fixturedef(self, fixturedef: FixtureDef, request: FixtureRequest):
+        if fixturedef.params and "request" in fixturedef.argnames:
+            try:
+                parameter = str(request.param)
+            except Exception:
+                parameter = str(
+                    request.param_index if isinstance(request, SubRequest) else "?"
+                )
+            return f"{fixturedef.argname}[{parameter}]"
+        return fixturedef.argname
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_fixture_setup(
+        self, fixturedef: FixtureDef, request: FixtureRequest
+    ) -> Generator[None, None, None]:
+        with tracer.start_as_current_span(
+            name=f"{self._name_from_fixturedef(fixturedef, request)} setup",
+            attributes=self._attributes_from_fixturedef(fixturedef),
+        ):
+            yield
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_call(self, item: Item) -> Generator[None, None, None]:
+        with tracer.start_as_current_span(
+            name=f"{item.nodeid}::call",
+            attributes=self._attributes_from_item(item),
+        ):
+            yield
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_runtest_teardown(self, item: Item) -> Generator[None, None, None]:
+        with tracer.start_as_current_span(
+            name=f"{item.nodeid}::teardown",
+            attributes=self._attributes_from_item(item),
+        ):
+            # Since there is no pytest_fixture_teardown hook, we have to be a
+            # little clever to capture the spans for each fixture's teardown.
+            # The pytest_fixture_post_finalizer hook is called at the end of a
+            # fixture's teardown, but we don't know when the fixture actually
+            # began tearing down.
+            #
+            # Instead start a span here for the first fixture to be torn down,
+            # but give it a temporary name, since we don't know which fixture it
+            # will be. Then, in pytest_fixture_post_finalizer, when we do know
+            # which fixture is being torn down, update the name and attributes
+            # to the actual fixture, end the span, and create the span for the
+            # next fixture in line to be torn down.
+            self._fixture_teardown_span = tracer.start_span("fixture teardown")
+            yield
+
+        # The last call to pytest_fixture_post_finalizer will create
+        # a span that is unneeded, so delete it.
+        del self._fixture_teardown_span
+
+    @pytest.hookimpl(hookwrapper=True)
+    def pytest_fixture_post_finalizer(
+        self, fixturedef: FixtureDef, request: SubRequest
+    ) -> Generator[None, None, None]:
+        """When the span for a fixture teardown is created by
+        pytest_runtest_teardown or a previous pytest_fixture_post_finalizer, we
+        need to update the name and attributes now that we know which fixture it
+        was for."""
+
+        # If the fixture has already been torn down, then it will have no cached
+        # result, so we can skip this one.
+        if fixturedef.cached_result is None:
+            yield
+        # Passing `-x` option to pytest can cause it to exit early so it may not
+        # have this span attribute.
+        elif not hasattr(self, "_fixture_teardown_span"):  # pragma: no cover
+            yield
+        else:
+            # If we've gotten here, we have a real fixture about to be torn down.
+            name = f"{self._name_from_fixturedef(fixturedef, request)} teardown"
+            self._fixture_teardown_span.update_name(name)
+            attributes = self._attributes_from_fixturedef(fixturedef)
+            self._fixture_teardown_span.set_attributes(attributes)
+            yield
+            self._fixture_teardown_span.end()
+
+        # Create the span for the next fixture to be torn down. When there are
+        # no more fixtures remaining, this will be an empty, useless span, so it
+        # needs to be deleted by pytest_runtest_teardown.
+        self._fixture_teardown_span = tracer.start_span("fixture teardown")
+
+    @staticmethod
+    def pytest_exception_interact(
+        node: Node,
+        call: CallInfo[Any],
+        report: TestReport,
+    ) -> None:
+        excinfo = call.excinfo
+        assert excinfo
+        assert isinstance(excinfo.value, BaseException)
+
+        test_span = trace.get_current_span()
+
+        test_span.record_exception(
+            # Interface says Exception, but BaseException seems to work fine
+            # This is needed because pytest's Failed exception inherits from
+            # BaseException, not Exception
+            exception=excinfo.value,  # type: ignore[arg-type]
+            attributes={
+                SpanAttributes.EXCEPTION_STACKTRACE: str(report.longrepr),
+            },
+        )
+        test_span.set_status(
+            Status(
+                status_code=StatusCode.ERROR,
+                description=f"{excinfo.type}: {excinfo.value}",
+            )
+        )
+
+    def pytest_runtest_logreport(self, report: TestReport) -> None:
+        if report.when != "call":
+            return
+
+        has_error = report.outcome == "failed"
+        status_code = StatusCode.ERROR if has_error else StatusCode.OK
+        self.has_error |= has_error
+        test_span = trace.get_current_span()
+        test_span.set_status(status_code)
+        test_span.set_attribute(
+            "test.case.result.status", "fail" if has_error else "pass"
+        )
+
+
+try:
+    from xdist.workermanage import WorkerController  # pylint: disable=unused-import
+except ImportError:  # pragma: no cover
+    WorkerController = None
+
+
+class XdistOpenTelemetryPlugin(OpenTelemetryPlugin):
+    """An xdist-aware version of the OpenTelemetryPlugin"""
+
+    @classmethod
+    def get_trace_parent(cls, config: Config) -> Optional[Context]:
+        if workerinput := getattr(config, "workerinput", None):
+            return propagate.extract(workerinput)
+
+        return super().get_trace_parent(config)
+
+    def pytest_configure(self, config: Config) -> None:
+        super().pytest_configure(config)
+        worker_id = getattr(config, "workerinput", {}).get("workerid")
+        self.session_name = (
+            f"test worker {worker_id}" if worker_id else self.session_name
+        )
+
+    def pytest_configure_node(self, node: WorkerController) -> None:  # pragma: no cover
+        with trace.use_span(self.session_span, end_on_exit=False):
+            propagate.inject(node.workerinput)
+
+    def pytest_xdist_node_collection_finished(node, ids):  # pragma: no cover
+        super().try_force_flush()

--- a/example_tests/health_check_test.py
+++ b/example_tests/health_check_test.py
@@ -1,51 +1,114 @@
-from datetime import datetime
-from dateutil.relativedelta import relativedelta
-from typing import Any, AsyncIterable, Sequence, Type, assert_never
+import asyncio
+from datetime import datetime, timedelta
+from typing import Any, AsyncIterable, Coroutine, Iterable
 from opensearchpy import AsyncOpenSearch
-from pydantic import BaseModel
 import pytest
 from opentelemetry import trace
 from opentelemetry.util import types
-from opentelemetry.trace.span import Span
 
+from python_opentelemetry_access import otlpjson, proxy
+from python_opentelemetry_access.base import Span
 from python_opentelemetry_access.proxy.opensearch.ss4o import OpenSearchSS40Proxy
-
-tracer = trace.get_tracer("pytest-opentelemetry")
 
 
 type NestedDict = dict[str, NestedDict | types.AttributeValue]
 
 
-def flatten_internal(d: NestedDict, name: str) -> dict[str, types.AttributeValue]:
-    result: dict[str, types.AttributeValue] = {}
-    if name:
-        name += "."
-    for key, value in d.items():
-        cur_name = name + key
-        match value:
-            case int() | str() | float() | bool() | Sequence():
-                result[cur_name] = value
-            case dict():
-                result |= flatten_internal(value, cur_name)
-            case unreachable:
-                assert_never(unreachable)
-    return result
+def _get_fields_attr_name(data_name: str) -> str:
+    return f"data_{data_name}_fields"
 
 
-def flatten(d: NestedDict) -> dict[str, types.AttributeValue]:
-    return flatten_internal(d, "")
+# THESE TWO functions should probably be the new API, at least for the simplest cases
+# THOUGH with this you don't get span length. Might include span length in the result?
+def save_data(data_name: str, data: dict[str, types.AttributeValue]) -> None:
+    cur_span = trace.get_current_span()
+    cur_span.set_attribute(_get_fields_attr_name(data_name), list(data.keys()))
+    trace.get_current_span().set_attributes(data)
 
 
-def set_span_attributes(span: Span, data: BaseModel) -> None:
-    span.set_attributes(flatten_internal(data.model_dump(), ""))
+async def load_data_from_name_async(
+    proxy: proxy.Proxy, data_name: str, max_data_age: timedelta
+) -> AsyncIterable[dict[str, types.AttributeValue]]:
+    try:
+        now = datetime.now()
+        fields_attr_name = _get_fields_attr_name(data_name)
+        async for spanCollection in proxy.query_spans_async(
+            from_time=now - max_data_age,
+            to_time=now,
+            span_attributes={fields_attr_name: None},
+        ):
+            for _resource, _scope, span in spanCollection.iter_spans():
+                # fields = [
+                #     expect_str(field)
+                #     for field in expect_list(span.otlp_attributes[fields_attr_name])
+                # ]
+                fields = span.otlp_attributes[fields_attr_name]
+                yield {field: span.otlp_attributes[field] for field in fields}  # type: ignore
+    finally:
+        await proxy.aclose()
 
 
-async def get_data[T: BaseModel](
-    data_type: Type[T],
-    span_name: str,
-    from_time: datetime | None,
-    to_time: datetime | None,
-) -> AsyncIterable[T]:
+async def load_span_from_fields_async(
+    proxy: proxy.Proxy, data_fields: list[str], max_data_age: timedelta
+) -> AsyncIterable[Span]:
+    try:
+        now = datetime.now()
+        async for spanCollection in proxy.query_spans_async(
+            from_time=now - max_data_age,
+            to_time=now,
+            span_attributes={field: None for field in data_fields},
+        ):
+            for _resource, _scope, span in spanCollection.iter_spans():
+                yield span
+    finally:
+        await proxy.aclose()
+
+
+async def load_span_from_span_name_async(
+    proxy: proxy.Proxy, span_name: str, max_data_age: timedelta
+) -> AsyncIterable[Span]:
+    try:
+        now = datetime.now()
+        async for spanCollection in proxy.query_spans_async(
+            from_time=now - max_data_age, to_time=now, span_name=span_name
+        ):
+            for _resource, _scope, span in spanCollection.iter_spans():
+                yield span
+    finally:
+        await proxy.aclose()
+
+
+async def async_list[T](
+    async_iterable: AsyncIterable[T],
+) -> Iterable[T]:
+    # TODO: would be nice to return the values as they become available, not accumulate them all first
+    results: list[T] = []
+    async for data in async_iterable:
+        results.append(data)
+    return results
+
+
+def async_to_sync_iterable[T](
+    async_iterable: AsyncIterable[T],
+) -> Iterable[T]:
+    return asyncio.run(async_list(async_iterable))
+
+
+def load_data_sync(
+    proxy: proxy.Proxy, data_name: str, max_data_age: timedelta
+) -> Iterable[dict[str, types.AttributeValue]]:
+    return async_to_sync_iterable(
+        load_data_from_name_async(proxy, data_name, max_data_age)
+    )
+    # return asyncio.run(_load_data_internal(proxy, data_name, max_data_age))
+
+
+def get_mock_proxy(file: str) -> proxy.Proxy:
+    with open(file, "r") as f:
+        return proxy.MockProxy(otlpjson.load(f))
+
+
+def get_opensearch_proxy() -> proxy.Proxy:
     opensearch_params: dict[str, Any] = {}
 
     # if osuser is not None and ospass is not None:
@@ -60,37 +123,72 @@ async def get_data[T: BaseModel](
         use_ssl=True,
         **opensearch_params,
     )
-    proxy = OpenSearchSS40Proxy(client)
-    try:
-        async for spanCollection in proxy.query_spans_async(from_time, to_time):
-            for resource, scope, span in spanCollection.iter_spans():
-                if span.otlp_name == span_name:
-                    # TODO: unflatten the data
-                    yield data_type.model_validate(span.otlp_attributes)
-    finally:
-        await client.close()
-
-
-class Data(BaseModel):
-    foo: int
-    bar: list[str]
+    return OpenSearchSS40Proxy(client)
 
 
 INFO_DUMP_SPAN_NAME = "INFO_DUMP"
 
 
+# def test_bla() -> None:
+#     with tracer.start_as_current_span("HELLO_SPAN") as span:
+#         span.set_attribute("hello", [1, 2, 3])
+
+
 def test_generate_data() -> None:
-    with tracer.start_as_current_span(INFO_DUMP_SPAN_NAME) as info_dump_span:
-        data = Data(foo=5, bar=["a", "bb", "ccc"])
-        set_span_attributes(info_dump_span, data)
+    save_data(data_name="my_data", data={"results": [1.0, 2.0, 2.0]})
+
+
+def test_get_requests_sync() -> None:
+    sum_sum = 0.0
+    sum_count = 0
+    for data in load_data_sync(
+        proxy=get_mock_proxy("example_tests/test_spans.json"),
+        data_name="my_data",
+        max_data_age=timedelta(weeks=4),
+    ):
+        sum_sum += sum(data["results"])
+        sum_count += 1
+    assert sum_sum / sum_count < 2.0
 
 
 @pytest.mark.asyncio
-async def test_read_data() -> None:
-    async for data in get_data(
-        data_type=Data,
-        span_name=INFO_DUMP_SPAN_NAME,
-        from_time=datetime.now() + relativedelta(months=-1),
-        to_time=datetime.now(),
+async def test_get_requests_async() -> None:
+    sum_sum = 0.0
+    sum_count = 0
+    async for data in load_data_from_name_async(
+        proxy=get_mock_proxy("example_tests/test_spans.json"),
+        data_name="my_data",
+        max_data_age=timedelta(weeks=4),
     ):
-        assert data.foo < 5
+        sum_sum += sum(data["results"])
+        sum_count += 1
+    assert sum_sum / sum_count < 2.0
+
+
+# # TODO: make this function unnecessary. proxy.query_spans_async should be able to do all the necessary filtering by itself
+# async def get_spans_with_data(
+#     proxy: proxy.Proxy,
+#     required_attributes: list[str],
+#     from_time: datetime | None,
+#     to_time: datetime | None,
+# ) -> AsyncIterable[base.Span]:
+#     async for spanCollection in proxy.query_spans_async(from_time, to_time):
+#         for _resource, _scope, span in spanCollection.iter_spans():
+#             # TODO: filter by these
+#             if all(attr in span.otlp_attributes for attr in required_attributes):
+#                 yield span
+
+
+# @pytest.mark.asyncio
+# async def test_get_requests() -> None:
+#     proxy = get_opensearch_proxy()
+#     try:
+#         async for span in get_spans_with_data(
+#             proxy=proxy,
+#             required_attributes=["http.status_code", "http.url", "http.method"],
+#             from_time=datetime.now() + relativedelta(months=-1),
+#             to_time=datetime.now(),
+#         ):
+#             assert span.otlp_attributes["http.status_code"] == 200
+#     finally:
+#         await proxy.aclose()

--- a/example_tests/health_check_test.py
+++ b/example_tests/health_check_test.py
@@ -1,23 +1,42 @@
-import asyncio
-from dataclasses import dataclass
-from datetime import datetime, timedelta
-from typing import Any, AsyncIterable, Iterable, Optional
+from datetime import timedelta
+from typing import Any, AsyncIterable, Iterable
 from opensearchpy import AsyncOpenSearch
 import pytest
 from opentelemetry import trace
 from opentelemetry.util import types
 
-from python_opentelemetry_access import otlpjson, proxy
-from python_opentelemetry_access.base import Span
+from python_opentelemetry_access import otlpjson
+from python_opentelemetry_access import util
+from python_opentelemetry_access.proxy import MockProxy, Proxy
 from python_opentelemetry_access.proxy.opensearch.ss4o import OpenSearchSS40Proxy
-from python_opentelemetry_access.util import AttributesFilter
-
-
-# type NestedDict = dict[str, NestedDict | types.AttributeValue]
 
 
 def _get_fields_attr_name(data_name: str) -> str:
     return f"data_{data_name}_fields"
+
+
+async def load_data_from_name_async(
+    proxy: Proxy, data_name: str, max_data_age: timedelta
+) -> AsyncIterable[util.CheckData]:
+    fields_attr_name = _get_fields_attr_name(data_name)
+    async for data in proxy.load_span_data_async(
+        span_name=None,
+        span_attributes={fields_attr_name: None},
+        max_data_age=max_data_age,
+    ):
+        fields: list[str] = data.attributes[fields_attr_name]
+        yield util.CheckData(
+            span_duration=data.span_duration,
+            attributes={field: data.attributes[field] for field in fields},
+        )
+
+
+def load_data_from_name_sync(
+    proxy: Proxy, data_name: str, max_data_age: timedelta
+) -> Iterable[util.CheckData]:
+    return util.async_to_sync_iterable(
+        load_data_from_name_async(proxy, data_name, max_data_age)
+    )
 
 
 def save_data(data_name: str, data: dict[str, types.AttributeValue]) -> None:
@@ -26,133 +45,12 @@ def save_data(data_name: str, data: dict[str, types.AttributeValue]) -> None:
     cur_span.set_attributes(data)
 
 
-@dataclass
-class Data:
-    span_duration: timedelta
-    attributes: dict[str, Any]
-
-
-def get_span_duration(span: Span) -> timedelta:
-    result = timedelta(
-        seconds=(span.otlp_end_time_unix_nano - span.otlp_start_time_unix_nano)
-        / 1_000_000_000
-    )
-    return result
-
-
-async def _load_data_async(
-    proxy: proxy.Proxy,
-    span_name: Optional[str],
-    span_attributes: Optional[AttributesFilter],
-    max_data_age: timedelta,
-) -> AsyncIterable[Data]:
-    try:
-        now = datetime.now()
-        async for spanCollection in proxy.query_spans_async(
-            from_time=now - max_data_age,
-            to_time=now,
-            span_attributes=span_attributes,
-            span_name=span_name,
-        ):
-            for _resource, _scope, span in spanCollection.iter_spans():
-                yield Data(
-                    span_duration=get_span_duration(span),
-                    attributes=span.otlp_attributes,
-                )
-    finally:
-        await proxy.aclose()
-
-
-async def load_data_from_name_async(
-    proxy: proxy.Proxy, data_name: str, max_data_age: timedelta
-) -> AsyncIterable[Data]:
-    fields_attr_name = _get_fields_attr_name(data_name)
-    async for data in _load_data_async(
-        proxy,
-        span_name=None,
-        span_attributes={fields_attr_name: None},
-        max_data_age=max_data_age,
-    ):
-        fields: list[str] = data.attributes[fields_attr_name]
-        yield Data(
-            span_duration=data.span_duration,
-            attributes={field: data.attributes[field] for field in fields},
-        )
-
-
-def load_data_from_fields_async(
-    proxy: proxy.Proxy,
-    data_fields: list[str],
-    max_data_age: timedelta,
-) -> AsyncIterable[Data]:
-    return _load_data_async(
-        proxy=proxy,
-        span_name=None,
-        span_attributes={field: None for field in data_fields},
-        max_data_age=max_data_age,
-    )
-
-
-def load_span_data_async(
-    proxy: proxy.Proxy,
-    span_name: str | None,
-    span_attributes: AttributesFilter | None,
-    max_data_age: timedelta,
-) -> AsyncIterable[Data]:
-    return _load_data_async(
-        proxy, span_name=span_name, span_attributes=None, max_data_age=max_data_age
-    )
-
-
-async def _async_list[T](
-    async_iterable: AsyncIterable[T],
-) -> Iterable[T]:
-    # TODO: would be nice to return the values as they become available, not accumulate them all first
-    results: list[T] = []
-    async for data in async_iterable:
-        results.append(data)
-    return results
-
-
-def _async_to_sync_iterable[T](
-    async_iterable: AsyncIterable[T],
-) -> Iterable[T]:
-    return asyncio.run(_async_list(async_iterable))
-
-
-def load_data_sync(
-    proxy: proxy.Proxy, data_name: str, max_data_age: timedelta
-) -> Iterable[Data]:
-    return _async_to_sync_iterable(
-        load_data_from_name_async(proxy, data_name, max_data_age)
-    )
-
-
-def load_data_from_fields_sync(
-    proxy: proxy.Proxy, data_fields: list[str], max_data_age: timedelta
-) -> Iterable[Data]:
-    return _async_to_sync_iterable(
-        load_data_from_fields_async(proxy, data_fields, max_data_age)
-    )
-
-
-def load_span_data_sync(
-    proxy: proxy.Proxy,
-    span_name: str | None,
-    span_attributes: AttributesFilter | None,
-    max_data_age: timedelta,
-) -> Iterable[Data]:
-    return _async_to_sync_iterable(
-        load_span_data_async(proxy, span_name, span_attributes, max_data_age)
-    )
-
-
-def get_mock_proxy(file: str) -> proxy.Proxy:
+def get_mock_proxy(file: str) -> Proxy:
     with open(file, "r") as f:
-        return proxy.MockProxy(otlpjson.load(f))
+        return MockProxy(otlpjson.load(f))
 
 
-def get_opensearch_proxy() -> proxy.Proxy:
+def get_opensearch_proxy() -> Proxy:
     opensearch_params: dict[str, Any] = {}
 
     # if osuser is not None and ospass is not None:
@@ -176,8 +74,7 @@ def get_opensearch_proxy() -> proxy.Proxy:
 def test_requests_duration() -> None:
     duration_sum = timedelta()
     duration_count = 0
-    for data in load_span_data_sync(
-        proxy=get_opensearch_proxy(),
+    for data in get_opensearch_proxy().load_span_data_sync(
         span_name="GET",
         span_attributes={
             "http.url": ["https://openeo.dataspace.copernicus.eu/openeo/1.2"]
@@ -197,7 +94,7 @@ def test_generate_data() -> None:
 def test_get_requests_sync() -> None:
     sum_sum = 0.0
     sum_count = 0
-    for data in load_data_sync(
+    for data in load_data_from_name_sync(
         proxy=get_mock_proxy("example_tests/test_spans.json"),
         data_name="my_data",
         max_data_age=timedelta(weeks=4),

--- a/example_tests/health_check_test.py
+++ b/example_tests/health_check_test.py
@@ -39,7 +39,7 @@ def load_data_from_name_sync(
     )
 
 
-def save_data(data_name: str, data: dict[str, types.AttributeValue]) -> None:
+def report_data(data_name: str, data: dict[str, types.AttributeValue]) -> None:
     cur_span = trace.get_current_span()
     cur_span.set_attribute(_get_fields_attr_name(data_name), list(data.keys()))
     cur_span.set_attributes(data)
@@ -95,7 +95,7 @@ def test_requests_duration(proxy: Proxy) -> None:
 
 
 def test_generate_data() -> None:
-    save_data(data_name="my_data", data={"results": [1.0, 2.0, 2.0]})
+    report_data(data_name="my_data", data={"results": [1.0, 2.0, 2.0]})
 
 
 def test_get_requests_sync(proxy: Proxy) -> None:

--- a/example_tests/health_check_test.py
+++ b/example_tests/health_check_test.py
@@ -20,12 +20,10 @@ def _get_fields_attr_name(data_name: str) -> str:
     return f"data_{data_name}_fields"
 
 
-# THESE TWO functions should probably be the new API, at least for the simplest cases
-# THOUGH with this you don't get span length. Might include span length in the result?
 def save_data(data_name: str, data: dict[str, types.AttributeValue]) -> None:
     cur_span = trace.get_current_span()
     cur_span.set_attribute(_get_fields_attr_name(data_name), list(data.keys()))
-    trace.get_current_span().set_attributes(data)
+    cur_span.set_attributes(data)
 
 
 @dataclass
@@ -39,7 +37,6 @@ def get_span_duration(span: Span) -> timedelta:
         seconds=(span.otlp_end_time_unix_nano - span.otlp_start_time_unix_nano)
         / 1_000_000_000
     )
-    print(span.otlp_end_time_unix_nano - span.otlp_start_time_unix_nano, result)
     return result
 
 

--- a/example_tests/health_check_test.py
+++ b/example_tests/health_check_test.py
@@ -68,13 +68,20 @@ def get_opensearch_proxy() -> Proxy:
     return OpenSearchSS40Proxy(client)
 
 
+@pytest.fixture
+def proxy() -> Proxy:
+    return get_mock_proxy("example_tests/test_spans.json")
+
+
 # USER DEFINED CODE START
 
 
-def test_requests_duration() -> None:
+def test_requests_duration(proxy: Proxy) -> None:
+    # proxy = get_opensearch_proxy()
+    proxy = get_mock_proxy("example_tests/test_spans.json")
     duration_sum = timedelta()
     duration_count = 0
-    for data in get_opensearch_proxy().load_span_data_sync(
+    for data in proxy.load_span_data_sync(
         span_name="GET",
         span_attributes={
             "http.url": ["https://openeo.dataspace.copernicus.eu/openeo/1.2"]
@@ -91,11 +98,11 @@ def test_generate_data() -> None:
     save_data(data_name="my_data", data={"results": [1.0, 2.0, 2.0]})
 
 
-def test_get_requests_sync() -> None:
+def test_get_requests_sync(proxy: Proxy) -> None:
     sum_sum = 0.0
     sum_count = 0
     for data in load_data_from_name_sync(
-        proxy=get_mock_proxy("example_tests/test_spans.json"),
+        proxy=proxy,
         data_name="my_data",
         max_data_age=timedelta(weeks=4),
     ):
@@ -105,11 +112,11 @@ def test_get_requests_sync() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_requests_async() -> None:
+async def test_get_requests_async(proxy: Proxy) -> None:
     sum_sum = 0.0
     sum_count = 0
     async for data in load_data_from_name_async(
-        proxy=get_mock_proxy("example_tests/test_spans.json"),
+        proxy=proxy,
         data_name="my_data",
         max_data_age=timedelta(weeks=4),
     ):

--- a/example_tests/health_check_test.py
+++ b/example_tests/health_check_test.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+from typing import Any, AsyncIterable, Sequence, Type, assert_never
+from opensearchpy import AsyncOpenSearch
+from pydantic import BaseModel
+import pytest
+from opentelemetry import trace
+from opentelemetry.util import types
+from opentelemetry.trace.span import Span
+
+from python_opentelemetry_access.proxy.opensearch.ss4o import OpenSearchSS40Proxy
+
+tracer = trace.get_tracer("pytest-opentelemetry")
+
+
+type NestedDict = dict[str, NestedDict | types.AttributeValue]
+
+
+def flatten_internal(d: NestedDict, name: str) -> dict[str, types.AttributeValue]:
+    result: dict[str, types.AttributeValue] = {}
+    if name:
+        name += "."
+    for key, value in d.items():
+        cur_name = name + key
+        match value:
+            case int() | str() | float() | bool() | Sequence():
+                result[cur_name] = value
+            case dict():
+                result |= flatten_internal(value, cur_name)
+            case unreachable:
+                assert_never(unreachable)
+    return result
+
+
+def flatten(d: NestedDict) -> dict[str, types.AttributeValue]:
+    return flatten_internal(d, "")
+
+
+def set_span_attributes(span: Span, data: BaseModel) -> None:
+    span.set_attributes(flatten_internal(data.model_dump(), ""))
+
+
+async def get_data[T: BaseModel](
+    data_type: Type[T],
+    span_name: str,
+    from_time: datetime | None,
+    to_time: datetime | None,
+) -> AsyncIterable[T]:
+    opensearch_params: dict[str, Any] = {}
+
+    # if osuser is not None and ospass is not None:
+    #     opensearch_params["http_auth"] = (osuser, ospass)
+    opensearch_params["ca_certs"] = "tmp/tmp_certs/ca.crt"
+    opensearch_params["client_cert"] = "tmp/tmp_certs/tls.crt"
+    opensearch_params["client_key"] = "tmp/tmp_certs/tls.key"
+    opensearch_params.update({"verify_certs": True, "ssl_show_warn": True})
+
+    client = AsyncOpenSearch(
+        hosts=[{"host": "opensearch-cluster-master-headless", "port": 9200}],
+        use_ssl=True,
+        **opensearch_params,
+    )
+    proxy = OpenSearchSS40Proxy(client)
+    try:
+        async for spanCollection in proxy.query_spans_async(from_time, to_time):
+            for resource, scope, span in spanCollection.iter_spans():
+                if span.otlp_name == span_name:
+                    # TODO: unflatten the data
+                    yield data_type.model_validate(span.otlp_attributes)
+    finally:
+        await client.close()
+
+
+class Data(BaseModel):
+    foo: int
+    bar: list[str]
+
+
+INFO_DUMP_SPAN_NAME = "INFO_DUMP"
+
+
+def test_generate_data() -> None:
+    with tracer.start_as_current_span(INFO_DUMP_SPAN_NAME) as info_dump_span:
+        data = Data(foo=5, bar=["a", "bb", "ccc"])
+        set_span_attributes(info_dump_span, data)
+
+
+@pytest.mark.asyncio
+async def test_read_data() -> None:
+    async for data in get_data(
+        data_type=Data,
+        span_name=INFO_DUMP_SPAN_NAME,
+        from_time=datetime.now() + relativedelta(months=-1),
+        to_time=datetime.now(),
+    ):
+        assert data.foo < 5

--- a/example_tests/health_check_test.py
+++ b/example_tests/health_check_test.py
@@ -68,8 +68,6 @@ def proxy() -> Proxy:
 
 
 def test_requests_duration(proxy: Proxy) -> None:
-    # proxy = get_opensearch_proxy()
-    proxy = get_mock_proxy("example_tests/test_spans.json")
     duration_sum = timedelta()
     duration_count = 0
     for span in proxy.load_span_data_sync(
@@ -89,7 +87,7 @@ def test_generate_data() -> None:
     report_with_name(data_name="my_data", data={"results": [1.0, 2.0, 2.0]})
 
 
-def test_get_requests_sync(proxy: Proxy) -> None:
+def test_using_past_data_sync(proxy: Proxy) -> None:
     sum_sum = 0.0
     sum_count = 0
     for span in load_spans_from_data_name_sync(
@@ -103,7 +101,7 @@ def test_get_requests_sync(proxy: Proxy) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_requests_async(proxy: Proxy) -> None:
+async def test_using_past_data_async(proxy: Proxy) -> None:
     sum_sum = 0.0
     sum_count = 0
     async for span in load_spans_from_data_name_async(

--- a/example_tests/test_spans.json
+++ b/example_tests/test_spans.json
@@ -3844,6 +3844,2521 @@
                     ]
                 }
             ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "7476c08a27f26b8a8f4d34ce6e3a5bed1231aa6493f1f682212ac04d7d54ac7b"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-http-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-2"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "11fb21dac257ef8f470fc9cc59ab32e3",
+                            "spanId": "9bd83f0b50ece132",
+                            "parentSpanId": "dd0b4d5b98a1a352",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742428804865720322",
+                            "endTimeUnixNano": "1742428805457068521",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://www.google.com/"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "0971d6eed28e057f30d18307be549708f43fcf707bab5ad83dfcc42c6e6a1502"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-openeo-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-3"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "c0fda0d61f9ac35f2b143718e972d8be",
+                            "spanId": "af35bdce21ea6547",
+                            "parentSpanId": "3c4ebd1166f7cd30",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742428804898483791",
+                            "endTimeUnixNano": "1742428804983450766",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "c0fda0d61f9ac35f2b143718e972d8be",
+                            "spanId": "fd440f960ece721f",
+                            "parentSpanId": "48acd673b01789c4",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742428804986254670",
+                            "endTimeUnixNano": "1742428805038682733",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo-staging.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "c0fda0d61f9ac35f2b143718e972d8be",
+                            "spanId": "7e55b6660929b5cc",
+                            "parentSpanId": "ace0a45d1af3ff6d",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742428805041350003",
+                            "endTimeUnixNano": "1742428805073799413",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeofed.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "c0fda0d61f9ac35f2b143718e972d8be",
+                            "spanId": "cb2fae4a69fb5fab",
+                            "parentSpanId": "7faf9a3ed886bfc8",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742428805076426652",
+                            "endTimeUnixNano": "1742428805163417678",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeofed-staging.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "7476c08a27f26b8a8f4d34ce6e3a5bed1231aa6493f1f682212ac04d7d54ac7b"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-http-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-2"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "11fb21dac257ef8f470fc9cc59ab32e3",
+                            "spanId": "230c4a71ddc7531e",
+                            "parentSpanId": "8017572b9cbe2f2e",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742428805459881957",
+                            "endTimeUnixNano": "1742428805548710408",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://eoepca.org/"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "fea94228c7a9f3a20596770656166fc36bdad20ac9df50f6826e1f75cfcb4de1"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-openeo-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-3"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "d1821f87cc0af375849dae4c0361a5ad",
+                            "spanId": "c673dccd333ffe6f",
+                            "parentSpanId": "c851a6993a0de3ce",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742432404389897564",
+                            "endTimeUnixNano": "1742432404497619306",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d1821f87cc0af375849dae4c0361a5ad",
+                            "spanId": "a597f5111350cc0d",
+                            "parentSpanId": "30ce2eeb576c88cd",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742432404500733859",
+                            "endTimeUnixNano": "1742432404552028984",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo-staging.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d1821f87cc0af375849dae4c0361a5ad",
+                            "spanId": "dc248acbb67e2f76",
+                            "parentSpanId": "bd041912da529022",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742432404554750475",
+                            "endTimeUnixNano": "1742432404593298845",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeofed.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d1821f87cc0af375849dae4c0361a5ad",
+                            "spanId": "650f6a5062857395",
+                            "parentSpanId": "5809e3a0d6b3d9e7",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742432404596169281",
+                            "endTimeUnixNano": "1742432404652327262",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeofed-staging.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "d853d497e95949a4ba8b76761620c95f015f01d9d3a5463bafc8ff1d6683538a"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-http-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-2"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "a5c9af5d19680f93aaf733502fe24859",
+                            "spanId": "37377b3591f14497",
+                            "parentSpanId": "35dc3e535fb4fd8e",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742432404965917866",
+                            "endTimeUnixNano": "1742432405680148317",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://www.google.com/"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5c9af5d19680f93aaf733502fe24859",
+                            "spanId": "49d5214dd7b3ce21",
+                            "parentSpanId": "75d9d031c8cdaab0",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742432405682889651",
+                            "endTimeUnixNano": "1742432405710202954",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://eoepca.org/"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "c1642ca577d180f531217d75dc71fda3ec8431c5cfb0fe7b6b0703ab6cda3cae"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-http-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-2"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "27292f39df18b09c09e052b5995c6e76",
+                            "spanId": "ee38193370070974",
+                            "parentSpanId": "bb4f2c1437e275a5",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742436004570108793",
+                            "endTimeUnixNano": "1742436005278658545",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://www.google.com/"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "a84c0301d4a6652d7d62a3fb61bbb7c0ef5768913527f39b85f0d939310af932"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-openeo-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-3"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "7c86c1986d84a38b119465c5c2d433a5",
+                            "spanId": "b812c512540210d6",
+                            "parentSpanId": "6f082a830fd99007",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742436004703390486",
+                            "endTimeUnixNano": "1742436004778613585",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "7c86c1986d84a38b119465c5c2d433a5",
+                            "spanId": "c3f43106052d40ef",
+                            "parentSpanId": "2f71cdd40ff26a71",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742436004781453020",
+                            "endTimeUnixNano": "1742436004860070531",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo-staging.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "7c86c1986d84a38b119465c5c2d433a5",
+                            "spanId": "a17fcf87a294a873",
+                            "parentSpanId": "73c0db9183fe04d3",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742436004862806493",
+                            "endTimeUnixNano": "1742436004901036125",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeofed.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "7c86c1986d84a38b119465c5c2d433a5",
+                            "spanId": "1752c2cf47a539d2",
+                            "parentSpanId": "3efa3d2a77705c41",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742436004904251802",
+                            "endTimeUnixNano": "1742436004937246868",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeofed-staging.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "c1642ca577d180f531217d75dc71fda3ec8431c5cfb0fe7b6b0703ab6cda3cae"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-http-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-2"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "27292f39df18b09c09e052b5995c6e76",
+                            "spanId": "59b6195c68375ea1",
+                            "parentSpanId": "6f1dd90195519cae",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742436005281283813",
+                            "endTimeUnixNano": "1742436005308315601",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://eoepca.org/"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "b288bbd6e58cb9b7f09f4ebd20a3e6d4baf366ab929027984a3cc08a0be5900f"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-openeo-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-3"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "366c9908ddef14ccd3ba8b3411fff358",
+                            "spanId": "03f0697807ef764c",
+                            "parentSpanId": "e92d74f2f724f17e",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742439604413764171",
+                            "endTimeUnixNano": "1742439604490916300",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "366c9908ddef14ccd3ba8b3411fff358",
+                            "spanId": "a180c8e01b2d1766",
+                            "parentSpanId": "fb779a7a0eabddee",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742439604493836240",
+                            "endTimeUnixNano": "1742439604557895520",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://openeo-staging.dataspace.copernicus.eu/openeo/1.2"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "container.id",
+                        "value": {
+                            "stringValue": "3dc973748bda42ec501e64f994b8eeda07667f7d3f4236f4a8debe0406003666"
+                        }
+                    },
+                    {
+                        "key": "container.runtime",
+                        "value": {
+                            "stringValue": "docker"
+                        }
+                    },
+                    {
+                        "key": "health_check.name",
+                        "value": {
+                            "stringValue": "hourly-simple-http-check"
+                        }
+                    },
+                    {
+                        "key": "k8s.cronjob.name",
+                        "value": {
+                            "stringValue": "resource-health-healthchecks-cronjob-2"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/venv/bin/python"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/venv/bin/python /venv/bin/pytest --export-traces --suppress-tests-failed-exit-code tests.py --user-id defaultuser"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "pytest"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/usr/local/bin/python3.11"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "root"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "stringValue": "13"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.11.10 (main, Oct 19 2024, 01:04:28) [GCC 12.2.0]"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.11.10"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "unknown_service:pytest"
+                        }
+                    },
+                    {
+                        "key": "telemetry.auto.version",
+                        "value": {
+                            "stringValue": "0.46b0"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "user.id",
+                        "value": {
+                            "stringValue": "Health BB user"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "opentelemetry.instrumentation.requests",
+                        "version": "0.46b0"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "8fad0c49212f5bc5d766c2039d75b121",
+                            "spanId": "9ebc9eb1a8cfa235",
+                            "parentSpanId": "b9e94e8333faf8b8",
+                            "name": "GET",
+                            "kind": 3,
+                            "startTimeUnixNano": "1742439604515085577",
+                            "endTimeUnixNano": "1742439605114364323",
+                            "attributes": [
+                                {
+                                    "key": "data_stream",
+                                    "value": {
+                                        "kvlistValue": [
+                                            {
+                                                "key": "dataset",
+                                                "value": {
+                                                    "stringValue": "default"
+                                                }
+                                            },
+                                            {
+                                                "key": "namespace",
+                                                "value": {
+                                                    "stringValue": "namespace"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "span"
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "http.method",
+                                    "value": {
+                                        "stringValue": "GET"
+                                    }
+                                },
+                                {
+                                    "key": "http.status_code",
+                                    "value": {
+                                        "intValue": "200"
+                                    }
+                                },
+                                {
+                                    "key": "http.url",
+                                    "value": {
+                                        "stringValue": "https://www.google.com/"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }

--- a/example_tests/test_spans.json
+++ b/example_tests/test_spans.json
@@ -1,0 +1,3849 @@
+{
+    "resourceSpans": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "python-opentelemetry-access"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.12.7"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.12.7 (main, Oct 16 2024, 07:12:08) [Clang 18.1.8 ]"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "intValue": "74937"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/bin/python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3 /Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "jonaspuksta"
+                        }
+                    },
+                    {
+                        "key": "service.version",
+                        "value": {
+                            "stringValue": "e8d829a8db1d196b5229f48efcacdbbd47eda24b"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "pytest-opentelemetry"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "3459c5930c87ef3d",
+                            "parentSpanId": "9285d5e20ea6b9b5",
+                            "flags": 256,
+                            "name": "event_loop_policy setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533053535000",
+                            "endTimeUnixNano": "1742478533053582000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "9285d5e20ea6b9b5",
+                            "parentSpanId": "af42c0e4dafa2c4c",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533053374000",
+                            "endTimeUnixNano": "1742478533053663000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "d11bf9040cd3d732",
+                            "parentSpanId": "af42c0e4dafa2c4c",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533053773000",
+                            "endTimeUnixNano": "1742478533053845000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "data_my_data_fields",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "stringValue": "results"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "key": "results",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "doubleValue": 1
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "f97c2dc0424aa79e",
+                            "parentSpanId": "af42c0e4dafa2c4c",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533053962000",
+                            "endTimeUnixNano": "1742478533054125000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "af42c0e4dafa2c4c",
+                            "parentSpanId": "a14aeb87ee8f4623",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533053173000",
+                            "endTimeUnixNano": "1742478533054165000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "pass"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 1
+                            }
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "a956a363500e0bcb",
+                            "parentSpanId": "230a4969fb8fd35f",
+                            "flags": 256,
+                            "name": "event_loop setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533054409000",
+                            "endTimeUnixNano": "1742478533054658000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "230a4969fb8fd35f",
+                            "parentSpanId": "a434f9aa3d96abf7",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533054339000",
+                            "endTimeUnixNano": "1742478533054693000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "f8cc3961ac9c4306",
+                            "parentSpanId": "a434f9aa3d96abf7",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533054758000",
+                            "endTimeUnixNano": "1742478533055865000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "bd03bef1110db7aa",
+                            "parentSpanId": "0de76592b5e1673e",
+                            "flags": 256,
+                            "name": "event_loop teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533103182000",
+                            "endTimeUnixNano": "1742478533103581000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "81d0a15f6d4cdd80",
+                            "parentSpanId": "0de76592b5e1673e",
+                            "flags": 256,
+                            "name": "event_loop_policy teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533103605000",
+                            "endTimeUnixNano": "1742478533103652000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "0de76592b5e1673e",
+                            "parentSpanId": "a434f9aa3d96abf7",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533103161000",
+                            "endTimeUnixNano": "1742478533103730000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "a434f9aa3d96abf7",
+                            "parentSpanId": "a14aeb87ee8f4623",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478533054278000",
+                            "endTimeUnixNano": "1742478533103783000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "fail"
+                                    }
+                                }
+                            ],
+                            "events": [
+                                {
+                                    "timeUnixNano": "1742478533103064000",
+                                    "name": "exception",
+                                    "attributes": [
+                                        {
+                                            "key": "exception.type",
+                                            "value": {
+                                                "stringValue": "KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.message",
+                                            "value": {
+                                                "stringValue": "'results'"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.stacktrace",
+                                            "value": {
+                                                "stringValue": "@pytest.mark.asyncio\n    async def test_get_requests() -\u003e None:\n        proxy = get_mock_proxy(\"example_tests/test_spans.json\")\n        try:\n            sum_sum = 0.0\n            sum_count = 0\n            async for data in load_data(\n                proxy=proxy,\n                data_name=\"my_data\",\n                max_data_age=timedelta(weeks=4),\n            ):\n\u003e               sum_sum += sum(data[\"results\"])\nE               KeyError: 'results'\n\nexample_tests/new_health_check_test.py:92: KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.escaped",
+                                            "value": {
+                                                "stringValue": "False"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "status": {
+                                "message": "\u003cclass 'KeyError'\u003e: 'results'",
+                                "code": 2
+                            }
+                        },
+                        {
+                            "traceId": "f2b96d8df8d7a6ffec3536fa70db798f",
+                            "spanId": "a14aeb87ee8f4623",
+                            "parentSpanId": "",
+                            "flags": 256,
+                            "name": "test run",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478532619659000",
+                            "endTimeUnixNano": "1742478533103870000",
+                            "attributes": [
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "run"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "python-opentelemetry-access"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.12.7"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.12.7 (main, Oct 16 2024, 07:12:08) [Clang 18.1.8 ]"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "intValue": "75049"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/bin/python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3 /Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "jonaspuksta"
+                        }
+                    },
+                    {
+                        "key": "service.version",
+                        "value": {
+                            "stringValue": "e8d829a8db1d196b5229f48efcacdbbd47eda24b"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "pytest-opentelemetry"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "dbb254103008e1ca",
+                            "parentSpanId": "c04528f419b3c48c",
+                            "flags": 256,
+                            "name": "event_loop_policy setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541218306000",
+                            "endTimeUnixNano": "1742478541218350000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "c04528f419b3c48c",
+                            "parentSpanId": "f52c78d77d9d64b9",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541218206000",
+                            "endTimeUnixNano": "1742478541218403000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "3afbf2f91489229f",
+                            "parentSpanId": "f52c78d77d9d64b9",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541218486000",
+                            "endTimeUnixNano": "1742478541218552000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "data_my_data_fields",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "stringValue": "results"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "key": "results",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "doubleValue": 1
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "63706839c40a455a",
+                            "parentSpanId": "f52c78d77d9d64b9",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541218652000",
+                            "endTimeUnixNano": "1742478541218792000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "f52c78d77d9d64b9",
+                            "parentSpanId": "9037af6379cd5306",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541218058000",
+                            "endTimeUnixNano": "1742478541218829000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "pass"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 1
+                            }
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "a7fce039063098fa",
+                            "parentSpanId": "5ebb7ae77d05aa1e",
+                            "flags": 256,
+                            "name": "event_loop setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541219013000",
+                            "endTimeUnixNano": "1742478541219227000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "5ebb7ae77d05aa1e",
+                            "parentSpanId": "bd0b97a10c433261",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541218954000",
+                            "endTimeUnixNano": "1742478541219255000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "cfd45589ac2dbb51",
+                            "parentSpanId": "bd0b97a10c433261",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541219310000",
+                            "endTimeUnixNano": "1742478541220249000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "d205125f3f8d1500",
+                            "parentSpanId": "f0c9f54030fab0cb",
+                            "flags": 256,
+                            "name": "event_loop teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541266516000",
+                            "endTimeUnixNano": "1742478541266819000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "858a822295a78d30",
+                            "parentSpanId": "f0c9f54030fab0cb",
+                            "flags": 256,
+                            "name": "event_loop_policy teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541266836000",
+                            "endTimeUnixNano": "1742478541266869000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "f0c9f54030fab0cb",
+                            "parentSpanId": "bd0b97a10c433261",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541266499000",
+                            "endTimeUnixNano": "1742478541266938000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "bd0b97a10c433261",
+                            "parentSpanId": "9037af6379cd5306",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478541218905000",
+                            "endTimeUnixNano": "1742478541266987000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "fail"
+                                    }
+                                }
+                            ],
+                            "events": [
+                                {
+                                    "timeUnixNano": "1742478541266411000",
+                                    "name": "exception",
+                                    "attributes": [
+                                        {
+                                            "key": "exception.type",
+                                            "value": {
+                                                "stringValue": "KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.message",
+                                            "value": {
+                                                "stringValue": "'results'"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.stacktrace",
+                                            "value": {
+                                                "stringValue": "@pytest.mark.asyncio\n    async def test_get_requests() -\u003e None:\n        proxy = get_mock_proxy(\"example_tests/test_spans.json\")\n        try:\n            sum_sum = 0.0\n            sum_count = 0\n            async for data in load_data(\n                proxy=proxy,\n                data_name=\"my_data\",\n                max_data_age=timedelta(weeks=4),\n            ):\n\u003e               sum_sum += sum(data[\"results\"])\nE               KeyError: 'results'\n\nexample_tests/new_health_check_test.py:92: KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.escaped",
+                                            "value": {
+                                                "stringValue": "False"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "status": {
+                                "message": "\u003cclass 'KeyError'\u003e: 'results'",
+                                "code": 2
+                            }
+                        },
+                        {
+                            "traceId": "e82ec4b794d58d7505c0988f9720b834",
+                            "spanId": "9037af6379cd5306",
+                            "parentSpanId": "",
+                            "flags": 256,
+                            "name": "test run",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478540752779000",
+                            "endTimeUnixNano": "1742478541267065000",
+                            "attributes": [
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "run"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "python-opentelemetry-access"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.12.7"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.12.7 (main, Oct 16 2024, 07:12:08) [Clang 18.1.8 ]"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "intValue": "75098"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/bin/python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3 /Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "jonaspuksta"
+                        }
+                    },
+                    {
+                        "key": "service.version",
+                        "value": {
+                            "stringValue": "e8d829a8db1d196b5229f48efcacdbbd47eda24b"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "pytest-opentelemetry"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "2414d33ad563c7fa",
+                            "parentSpanId": "5bc58c44cc5207c3",
+                            "flags": 256,
+                            "name": "event_loop_policy setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544104059000",
+                            "endTimeUnixNano": "1742478544104098000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "5bc58c44cc5207c3",
+                            "parentSpanId": "c5b7fcf8e6380cb3",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544103969000",
+                            "endTimeUnixNano": "1742478544104152000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "972bcce601e38541",
+                            "parentSpanId": "c5b7fcf8e6380cb3",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544104243000",
+                            "endTimeUnixNano": "1742478544104303000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "data_my_data_fields",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "stringValue": "results"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "key": "results",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "doubleValue": 1
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "045acf470105935d",
+                            "parentSpanId": "c5b7fcf8e6380cb3",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544104402000",
+                            "endTimeUnixNano": "1742478544104539000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "c5b7fcf8e6380cb3",
+                            "parentSpanId": "e3ef216d291d113f",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544103822000",
+                            "endTimeUnixNano": "1742478544104574000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "pass"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 1
+                            }
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "8c3fb8a1fc794182",
+                            "parentSpanId": "5c1b8cee4bb8b176",
+                            "flags": 256,
+                            "name": "event_loop setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544104754000",
+                            "endTimeUnixNano": "1742478544104969000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "5c1b8cee4bb8b176",
+                            "parentSpanId": "df11e0a382f46b2d",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544104697000",
+                            "endTimeUnixNano": "1742478544105000000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "853445d0245f2869",
+                            "parentSpanId": "df11e0a382f46b2d",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544105062000",
+                            "endTimeUnixNano": "1742478544105746000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "10da5e03dfe9b1e0",
+                            "parentSpanId": "01ecc0bad4c369ee",
+                            "flags": 256,
+                            "name": "event_loop teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544149322000",
+                            "endTimeUnixNano": "1742478544149625000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "d351493e801a0a2d",
+                            "parentSpanId": "01ecc0bad4c369ee",
+                            "flags": 256,
+                            "name": "event_loop_policy teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544149642000",
+                            "endTimeUnixNano": "1742478544149673000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "01ecc0bad4c369ee",
+                            "parentSpanId": "df11e0a382f46b2d",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544149301000",
+                            "endTimeUnixNano": "1742478544149749000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "df11e0a382f46b2d",
+                            "parentSpanId": "e3ef216d291d113f",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478544104647000",
+                            "endTimeUnixNano": "1742478544149800000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "fail"
+                                    }
+                                }
+                            ],
+                            "events": [
+                                {
+                                    "timeUnixNano": "1742478544149211000",
+                                    "name": "exception",
+                                    "attributes": [
+                                        {
+                                            "key": "exception.type",
+                                            "value": {
+                                                "stringValue": "KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.message",
+                                            "value": {
+                                                "stringValue": "'results'"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.stacktrace",
+                                            "value": {
+                                                "stringValue": "@pytest.mark.asyncio\n    async def test_get_requests() -\u003e None:\n        proxy = get_mock_proxy(\"example_tests/test_spans.json\")\n        try:\n            sum_sum = 0.0\n            sum_count = 0\n            async for data in load_data(\n                proxy=proxy,\n                data_name=\"my_data\",\n                max_data_age=timedelta(weeks=4),\n            ):\n\u003e               sum_sum += sum(data[\"results\"])\nE               KeyError: 'results'\n\nexample_tests/new_health_check_test.py:92: KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.escaped",
+                                            "value": {
+                                                "stringValue": "False"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "status": {
+                                "message": "\u003cclass 'KeyError'\u003e: 'results'",
+                                "code": 2
+                            }
+                        },
+                        {
+                            "traceId": "a5bcf24ef6d0d6c660c4b9fade7aaf3b",
+                            "spanId": "e3ef216d291d113f",
+                            "parentSpanId": "",
+                            "flags": 256,
+                            "name": "test run",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478543717342000",
+                            "endTimeUnixNano": "1742478544149883000",
+                            "attributes": [
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "run"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "python-opentelemetry-access"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.12.7"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.12.7 (main, Oct 16 2024, 07:12:08) [Clang 18.1.8 ]"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "intValue": "75115"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/bin/python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3 /Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "jonaspuksta"
+                        }
+                    },
+                    {
+                        "key": "service.version",
+                        "value": {
+                            "stringValue": "e8d829a8db1d196b5229f48efcacdbbd47eda24b"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "pytest-opentelemetry"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "0d0b24161b33ae99",
+                            "parentSpanId": "ca7292f78a9a542b",
+                            "flags": 256,
+                            "name": "event_loop_policy setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545479546000",
+                            "endTimeUnixNano": "1742478545479585000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "ca7292f78a9a542b",
+                            "parentSpanId": "314bf7bfdd96b00a",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545479443000",
+                            "endTimeUnixNano": "1742478545479632000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "3fd874104e788a81",
+                            "parentSpanId": "314bf7bfdd96b00a",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545479715000",
+                            "endTimeUnixNano": "1742478545479776000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "data_my_data_fields",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "stringValue": "results"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "key": "results",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "doubleValue": 1
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "79f95a57ac375006",
+                            "parentSpanId": "314bf7bfdd96b00a",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545479877000",
+                            "endTimeUnixNano": "1742478545480010000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "314bf7bfdd96b00a",
+                            "parentSpanId": "619b48d2f5d0688b",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545479304000",
+                            "endTimeUnixNano": "1742478545480043000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "pass"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 1
+                            }
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "5c643d7c3200dfc1",
+                            "parentSpanId": "9fe3d8930c53595e",
+                            "flags": 256,
+                            "name": "event_loop setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545480220000",
+                            "endTimeUnixNano": "1742478545480450000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "9fe3d8930c53595e",
+                            "parentSpanId": "807b1d4c40aef484",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545480165000",
+                            "endTimeUnixNano": "1742478545480479000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "4b1f8a4997440f38",
+                            "parentSpanId": "807b1d4c40aef484",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545480537000",
+                            "endTimeUnixNano": "1742478545481262000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "fac1f22c73342898",
+                            "parentSpanId": "38d44a39a83f782b",
+                            "flags": 256,
+                            "name": "event_loop teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545524443000",
+                            "endTimeUnixNano": "1742478545524763000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "207ecbfcac141871",
+                            "parentSpanId": "38d44a39a83f782b",
+                            "flags": 256,
+                            "name": "event_loop_policy teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545524780000",
+                            "endTimeUnixNano": "1742478545524811000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "38d44a39a83f782b",
+                            "parentSpanId": "807b1d4c40aef484",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545524427000",
+                            "endTimeUnixNano": "1742478545524887000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "807b1d4c40aef484",
+                            "parentSpanId": "619b48d2f5d0688b",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545480118000",
+                            "endTimeUnixNano": "1742478545524934000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "fail"
+                                    }
+                                }
+                            ],
+                            "events": [
+                                {
+                                    "timeUnixNano": "1742478545524341000",
+                                    "name": "exception",
+                                    "attributes": [
+                                        {
+                                            "key": "exception.type",
+                                            "value": {
+                                                "stringValue": "KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.message",
+                                            "value": {
+                                                "stringValue": "'results'"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.stacktrace",
+                                            "value": {
+                                                "stringValue": "@pytest.mark.asyncio\n    async def test_get_requests() -\u003e None:\n        proxy = get_mock_proxy(\"example_tests/test_spans.json\")\n        try:\n            sum_sum = 0.0\n            sum_count = 0\n            async for data in load_data(\n                proxy=proxy,\n                data_name=\"my_data\",\n                max_data_age=timedelta(weeks=4),\n            ):\n\u003e               sum_sum += sum(data[\"results\"])\nE               KeyError: 'results'\n\nexample_tests/new_health_check_test.py:92: KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.escaped",
+                                            "value": {
+                                                "stringValue": "False"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "status": {
+                                "message": "\u003cclass 'KeyError'\u003e: 'results'",
+                                "code": 2
+                            }
+                        },
+                        {
+                            "traceId": "d75880c6c0134444976d62e846031f44",
+                            "spanId": "619b48d2f5d0688b",
+                            "parentSpanId": "",
+                            "flags": 256,
+                            "name": "test run",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478545107316000",
+                            "endTimeUnixNano": "1742478545525010000",
+                            "attributes": [
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "run"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "telemetry.sdk.language",
+                        "value": {
+                            "stringValue": "python"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.name",
+                        "value": {
+                            "stringValue": "opentelemetry"
+                        }
+                    },
+                    {
+                        "key": "telemetry.sdk.version",
+                        "value": {
+                            "stringValue": "1.25.0"
+                        }
+                    },
+                    {
+                        "key": "service.name",
+                        "value": {
+                            "stringValue": "python-opentelemetry-access"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.name",
+                        "value": {
+                            "stringValue": "cpython"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.version",
+                        "value": {
+                            "stringValue": "3.12.7"
+                        }
+                    },
+                    {
+                        "key": "process.runtime.description",
+                        "value": {
+                            "stringValue": "3.12.7 (main, Oct 16 2024, 07:12:08) [Clang 18.1.8 ]"
+                        }
+                    },
+                    {
+                        "key": "process.pid",
+                        "value": {
+                            "intValue": "75137"
+                        }
+                    },
+                    {
+                        "key": "process.executable.name",
+                        "value": {
+                            "stringValue": "python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.executable.path",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/.local/share/uv/python/cpython-3.12.7-macos-aarch64-none/bin/python3.12"
+                        }
+                    },
+                    {
+                        "key": "process.command_line",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3 /Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.command",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/python3"
+                        }
+                    },
+                    {
+                        "key": "process.command_args",
+                        "value": {
+                            "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/bin/pytest --export-traces example_tests"
+                        }
+                    },
+                    {
+                        "key": "process.owner",
+                        "value": {
+                            "stringValue": "jonaspuksta"
+                        }
+                    },
+                    {
+                        "key": "service.version",
+                        "value": {
+                            "stringValue": "e8d829a8db1d196b5229f48efcacdbbd47eda24b"
+                        }
+                    }
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {
+                        "name": "pytest-opentelemetry"
+                    },
+                    "spans": [
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "756a33969fcf98a4",
+                            "parentSpanId": "e8f27d2993ce244d",
+                            "flags": 256,
+                            "name": "event_loop_policy setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546856372000",
+                            "endTimeUnixNano": "1742478546856411000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "e8f27d2993ce244d",
+                            "parentSpanId": "e57b92298ccd7ea4",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546856286000",
+                            "endTimeUnixNano": "1742478546856459000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "f330665d5c039dbf",
+                            "parentSpanId": "e57b92298ccd7ea4",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546856550000",
+                            "endTimeUnixNano": "1742478546856610000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "data_my_data_fields",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "stringValue": "results"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "key": "results",
+                                    "value": {
+                                        "arrayValue": {
+                                            "values": [
+                                                {
+                                                    "doubleValue": 1
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                },
+                                                {
+                                                    "doubleValue": 2
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "5fa37f6b17fc9f80",
+                            "parentSpanId": "e57b92298ccd7ea4",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546856705000",
+                            "endTimeUnixNano": "1742478546856835000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "e57b92298ccd7ea4",
+                            "parentSpanId": "27fd67d72bb66b8b",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_generate_data",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546856146000",
+                            "endTimeUnixNano": "1742478546856870000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_generate_data"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "76"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "pass"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 1
+                            }
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "43e3b1e906591e02",
+                            "parentSpanId": "10b4f0a2070526c2",
+                            "flags": 256,
+                            "name": "event_loop setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546857050000",
+                            "endTimeUnixNano": "1742478546857269000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "10b4f0a2070526c2",
+                            "parentSpanId": "81fb5e343b3a07c9",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::setup",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546856992000",
+                            "endTimeUnixNano": "1742478546857299000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "183994acef358ed0",
+                            "parentSpanId": "81fb5e343b3a07c9",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::call",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546857356000",
+                            "endTimeUnixNano": "1742478546858221000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "643b42d1ae009e19",
+                            "parentSpanId": "9bca1969373a2467",
+                            "flags": 256,
+                            "name": "event_loop teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546902866000",
+                            "endTimeUnixNano": "1742478546903180000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1147"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "function"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "f92b755ac5b611d9",
+                            "parentSpanId": "9bca1969373a2467",
+                            "flags": 256,
+                            "name": "event_loop_policy teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546903197000",
+                            "endTimeUnixNano": "1742478546903234000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "/Users/jonaspuksta/workspace/python-opentelemetry-access/.venv/lib/python3.12/site-packages/pytest_asyncio/plugin.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "event_loop_policy"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "1187"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.fixture_scope",
+                                    "value": {
+                                        "stringValue": "session"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "fixture"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "9bca1969373a2467",
+                            "parentSpanId": "81fb5e343b3a07c9",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests::teardown",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546902850000",
+                            "endTimeUnixNano": "1742478546903307000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                }
+                            ],
+                            "status": {}
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "81fb5e343b3a07c9",
+                            "parentSpanId": "27fd67d72bb66b8b",
+                            "flags": 256,
+                            "name": "example_tests/new_health_check_test.py::test_get_requests",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546856944000",
+                            "endTimeUnixNano": "1742478546903354000",
+                            "attributes": [
+                                {
+                                    "key": "code.filepath",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py"
+                                    }
+                                },
+                                {
+                                    "key": "code.function",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.name",
+                                    "value": {
+                                        "stringValue": "test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.nodeid",
+                                    "value": {
+                                        "stringValue": "example_tests/new_health_check_test.py::test_get_requests"
+                                    }
+                                },
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "test"
+                                    }
+                                },
+                                {
+                                    "key": "code.lineno",
+                                    "value": {
+                                        "intValue": "80"
+                                    }
+                                },
+                                {
+                                    "key": "test.case.result.status",
+                                    "value": {
+                                        "stringValue": "fail"
+                                    }
+                                }
+                            ],
+                            "events": [
+                                {
+                                    "timeUnixNano": "1742478546902760000",
+                                    "name": "exception",
+                                    "attributes": [
+                                        {
+                                            "key": "exception.type",
+                                            "value": {
+                                                "stringValue": "KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.message",
+                                            "value": {
+                                                "stringValue": "'results'"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.stacktrace",
+                                            "value": {
+                                                "stringValue": "@pytest.mark.asyncio\n    async def test_get_requests() -\u003e None:\n        proxy = get_mock_proxy(\"example_tests/test_spans.json\")\n        try:\n            sum_sum = 0.0\n            sum_count = 0\n            async for data in load_data(\n                proxy=proxy,\n                data_name=\"my_data\",\n                max_data_age=timedelta(weeks=4),\n            ):\n\u003e               sum_sum += sum(data[\"results\"])\nE               KeyError: 'results'\n\nexample_tests/new_health_check_test.py:92: KeyError"
+                                            }
+                                        },
+                                        {
+                                            "key": "exception.escaped",
+                                            "value": {
+                                                "stringValue": "False"
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "status": {
+                                "message": "\u003cclass 'KeyError'\u003e: 'results'",
+                                "code": 2
+                            }
+                        },
+                        {
+                            "traceId": "ee8e0b34f049679317a5439ce2a2889c",
+                            "spanId": "27fd67d72bb66b8b",
+                            "parentSpanId": "",
+                            "flags": 256,
+                            "name": "test run",
+                            "kind": 1,
+                            "startTimeUnixNano": "1742478546473482000",
+                            "endTimeUnixNano": "1742478546903442000",
+                            "attributes": [
+                                {
+                                    "key": "pytest.span_type",
+                                    "value": {
+                                        "stringValue": "run"
+                                    }
+                                }
+                            ],
+                            "status": {
+                                "code": 2
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/example_tests/test_spans.json
+++ b/example_tests/test_spans.json
@@ -240,15 +240,9 @@
                                     }
                                 },
                                 {
-                                    "key": "data_my_data_fields",
+                                    "key": "my_data",
                                     "value": {
-                                        "arrayValue": {
-                                            "values": [
-                                                {
-                                                    "stringValue": "results"
-                                                }
-                                            ]
-                                        }
+                                        "boolValue": true
                                     }
                                 },
                                 {
@@ -1009,15 +1003,9 @@
                                     }
                                 },
                                 {
-                                    "key": "data_my_data_fields",
+                                    "key": "my_data",
                                     "value": {
-                                        "arrayValue": {
-                                            "values": [
-                                                {
-                                                    "stringValue": "results"
-                                                }
-                                            ]
-                                        }
+                                        "boolValue": true
                                     }
                                 },
                                 {
@@ -1778,15 +1766,9 @@
                                     }
                                 },
                                 {
-                                    "key": "data_my_data_fields",
+                                    "key": "my_data",
                                     "value": {
-                                        "arrayValue": {
-                                            "values": [
-                                                {
-                                                    "stringValue": "results"
-                                                }
-                                            ]
-                                        }
+                                        "boolValue": true
                                     }
                                 },
                                 {
@@ -2547,15 +2529,9 @@
                                     }
                                 },
                                 {
-                                    "key": "data_my_data_fields",
+                                    "key": "my_data",
                                     "value": {
-                                        "arrayValue": {
-                                            "values": [
-                                                {
-                                                    "stringValue": "results"
-                                                }
-                                            ]
-                                        }
+                                        "boolValue": true
                                     }
                                 },
                                 {
@@ -3316,15 +3292,9 @@
                                     }
                                 },
                                 {
-                                    "key": "data_my_data_fields",
+                                    "key": "my_data",
                                     "value": {
-                                        "arrayValue": {
-                                            "values": [
-                                                {
-                                                    "stringValue": "results"
-                                                }
-                                            ]
-                                        }
+                                        "boolValue": true
                                     }
                                 },
                                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,11 @@ dependencies = [
     "fastapi>=0.115.4",
     "opensearch-py[async]>=2.7.1",
     "opentelemetry-betterproto",
+    "opentelemetry-container-distro==0.2.0",
+    "opentelemetry-exporter-otlp==1.25.0",
     "pandas>=2.2.3",
+    "pytest-asyncio>=0.25.3",
+    "types-python-dateutil>=2.9.0.20241206",
     "uvicorn>=0.32.0",
 ]
 
@@ -31,3 +35,4 @@ opentelemetry-betterproto = { git = "https://github.com/EOEPCA/opentelemetry-bet
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_default_fixture_loop_scope = "function"

--- a/src/python_opentelemetry_access/api/__init__.py
+++ b/src/python_opentelemetry_access/api/__init__.py
@@ -12,12 +12,14 @@ from python_opentelemetry_access.api_utils.api_utils import (
     JSONAPIResponse,
     add_exception_handlers,
     get_api_router_with_defaults,
-    get_env_var_or_throw,
     get_request_url_str,
     get_url_str,
     set_custom_json_schema,
 )
-from python_opentelemetry_access.api_utils.exceptions import APIException, APIInternalError
+from python_opentelemetry_access.api_utils.exceptions import (
+    APIException,
+    APIInternalError,
+)
 from python_opentelemetry_access.api_utils.json_api_types import (
     APIOKResponseList,
     Error,
@@ -33,13 +35,19 @@ import python_opentelemetry_access.util as util
 @dataclass
 class Settings:
     _proxy: Optional[proxy.Proxy]
-    base_url: str
+    _base_url: Optional[str]
 
     @property
     def proxy(self) -> proxy.Proxy:
         if self._proxy is None:
             raise APIInternalError.create("No proxy initialised")
         return self._proxy
+
+    @property
+    def base_url(self) -> str:
+        if self._base_url is None:
+            raise APIInternalError.create("Base URL must be set")
+        return self._base_url
 
 
 class QueryParams(BaseModel):
@@ -94,9 +102,7 @@ def list_to_dict(values: list[str]) -> dict[str, list[str]]:
     return result
 
 
-settings = Settings(
-    _proxy=None, base_url=get_env_var_or_throw("RH_TELEMETRY_API_BASE_URL")
-)
+settings = Settings(_proxy=None, _base_url=None)
 
 
 async def run_query(

--- a/src/python_opentelemetry_access/api/__init__.py
+++ b/src/python_opentelemetry_access/api/__init__.py
@@ -84,7 +84,7 @@ type APIOKResponse = APIOKResponseList[
 
 
 def list_to_dict(values: list[str]) -> util.AttributesFilter:
-    result: util.AttributesFilter = {}
+    result: dict[str, Optional[list[str]]] = {}
     for value in values:
         match value.split("="):
             case [key]:
@@ -110,7 +110,8 @@ def list_to_dict(values: list[str]) -> util.AttributesFilter:
                         detail=f"Attribute filter parameter must be of the shape 'my awesome key=my awesome value'. '{value}' is of incorrect shape.",
                     )
                 )
-    return result
+    # To satisfy Mypy
+    return {key: value for key, value in result.items()}
 
 
 settings = Settings(_proxy=None, _base_url=None)

--- a/src/python_opentelemetry_access/base/__init__.py
+++ b/src/python_opentelemetry_access/base/__init__.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from datetime import timedelta
 from typing import Union, Protocol, Optional, Tuple, List, override
 from abc import abstractmethod
 import json
@@ -62,7 +63,7 @@ class OTLPData(Protocol):
     @abstractmethod
     def to_otlp_json_iter(self) -> util.JSONLikeIter:
         pass
-    
+
     def to_otlp_json_str_iter(self) -> Iterator[str]:
         return OTLPJSONEncoder().iterencode(self.to_otlp_json_iter())
 
@@ -463,6 +464,12 @@ class Span(OTLPData, Protocol):
     @abstractmethod
     def otlp_status(self) -> Status:
         pass
+
+    def duration(self) -> timedelta:
+        return timedelta(
+            seconds=(self.otlp_end_time_unix_nano - self.otlp_start_time_unix_nano)
+            / 1_000_000_000
+        )
 
 
 class InstrumentationScope(OTLPData, Protocol):

--- a/src/python_opentelemetry_access/cli/__init__.py
+++ b/src/python_opentelemetry_access/cli/__init__.py
@@ -6,6 +6,7 @@ import python_opentelemetry_access.otlpproto as otlpproto
 import python_opentelemetry_access.proxy as proxy_mod
 import python_opentelemetry_access.proxy.opensearch.ss4o as ss4o_proxy
 import python_opentelemetry_access.api as api
+from python_opentelemetry_access.api_utils.api_utils import get_env_var_or_throw
 
 import uvicorn
 from opensearchpy import AsyncOpenSearch
@@ -121,6 +122,7 @@ def convert(infile: Path, outfile: Path, from_: str, to: str) -> None:
 
 def run_proxy(ctx, proxy):
     api.settings._proxy = proxy
+    api.settings._base_url = get_env_var_or_throw("RH_TELEMETRY_API_BASE_URL")
 
     uvicorn.run(
         api.app,

--- a/src/python_opentelemetry_access/proxy/__init__.py
+++ b/src/python_opentelemetry_access/proxy/__init__.py
@@ -50,6 +50,7 @@ class Proxy(ABC):
             resource_attributes,
             scope_attributes,
             span_attributes,
+            span_name,
             page_token=starting_page_token,
         ):
             if isinstance(spans_or_page_token, PageToken):

--- a/src/python_opentelemetry_access/proxy/__init__.py
+++ b/src/python_opentelemetry_access/proxy/__init__.py
@@ -20,9 +20,10 @@ class Proxy(ABC):
         from_time: Optional[datetime] = None,
         to_time: Optional[datetime] = None,
         span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-        resource_attributes: Optional[dict[str, list[str]]] = None,
-        scope_attributes: Optional[dict[str, list[str]]] = None,
-        span_attributes: Optional[dict[str, list[str]]] = None,
+        resource_attributes: Optional[util.AttributesFilter] = None,
+        scope_attributes: Optional[util.AttributesFilter] = None,
+        span_attributes: Optional[util.AttributesFilter] = None,
+        span_name: Optional[str] = None,
         page_token: Optional[PageToken] = None,
     ) -> AsyncIterable[base.SpanCollection | PageToken]:
         # A trick to make the type of the function what I want
@@ -36,9 +37,10 @@ class Proxy(ABC):
         from_time: Optional[datetime] = None,
         to_time: Optional[datetime] = None,
         span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-        resource_attributes: Optional[dict[str, list[str]]] = None,
-        scope_attributes: Optional[dict[str, list[str]]] = None,
-        span_attributes: Optional[dict[str, list[str]]] = None,
+        resource_attributes: Optional[util.AttributesFilter] = None,
+        scope_attributes: Optional[util.AttributesFilter] = None,
+        span_attributes: Optional[util.AttributesFilter] = None,
+        span_name: Optional[str] = None,
         starting_page_token: Optional[PageToken] = None,
     ) -> AsyncIterable[base.SpanCollection]:
         async for spans_or_page_token in self.query_spans_page(
@@ -58,20 +60,31 @@ class Proxy(ABC):
                     resource_attributes,
                     scope_attributes,
                     span_attributes,
+                    span_name,
                     starting_page_token=spans_or_page_token,
                 ):
                     yield spans
             else:
                 yield spans_or_page_token
 
+    # Close connections, release resources and such
+    # aclose is the standard name such methods when they are asynchronous
+    @abstractmethod
+    async def aclose(self) -> None:
+        pass
+
 
 def _match_span(
     span: base.ReifiedSpan,
-    from_time: Optional[datetime] = None,
-    to_time: Optional[datetime] = None,
-    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-    span_attributes: Optional[dict[str, list[str]]] = None,
+    from_time: Optional[datetime],
+    to_time: Optional[datetime],
+    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]],
+    span_attributes: Optional[util.AttributesFilter],
+    span_name: Optional[str],
 ) -> bool:
+    if span_name is not None and span.name != span_name:
+        return False
+
     if (
         to_time is not None
         and span.start_time_unix_nano > to_time.timestamp() * 1000000000
@@ -98,15 +111,16 @@ def _match_span(
 
 def _filter_scope_span_collection(
     spans: base.ReifiedScopeSpanCollection,
-    from_time: Optional[datetime] = None,
-    to_time: Optional[datetime] = None,
-    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-    span_attributes: Optional[dict[str, list[str]]] = None,
+    from_time: Optional[datetime],
+    to_time: Optional[datetime],
+    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]],
+    span_attributes: Optional[util.AttributesFilter],
+    span_name: Optional[str],
 ) -> base.ReifiedScopeSpanCollection:
     spans.spans = [
         span
         for span in spans.spans
-        if _match_span(span, from_time, to_time, span_ids, span_attributes)
+        if _match_span(span, from_time, to_time, span_ids, span_attributes, span_name)
     ]
 
     return spans
@@ -114,15 +128,16 @@ def _filter_scope_span_collection(
 
 def _filter_resource_span_collection(
     spans: base.ReifiedResourceSpanCollection,
-    from_time: Optional[datetime] = None,
-    to_time: Optional[datetime] = None,
-    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-    scope_attributes: Optional[dict[str, list[str]]] = None,
-    span_attributes: Optional[dict[str, list[str]]] = None,
+    from_time: Optional[datetime],
+    to_time: Optional[datetime],
+    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]],
+    scope_attributes: Optional[util.AttributesFilter],
+    span_attributes: Optional[util.AttributesFilter],
+    span_name: Optional[str],
 ) -> base.ReifiedResourceSpanCollection:
     spans.scope_spans = [
         _filter_scope_span_collection(
-            inner_spans, from_time, to_time, span_ids, span_attributes
+            inner_spans, from_time, to_time, span_ids, span_attributes, span_name
         )
         for inner_spans in spans.scope_spans
         if util.match_attributes(
@@ -140,12 +155,13 @@ def _filter_resource_span_collection(
 
 def _filter_span_collection(
     spans: base.ReifiedSpanCollection,
-    from_time: Optional[datetime] = None,
-    to_time: Optional[datetime] = None,
-    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-    resource_attributes: Optional[dict[str, list[str]]] = None,
-    scope_attributes: Optional[dict[str, list[str]]] = None,
-    span_attributes: Optional[dict[str, list[str]]] = None,
+    from_time: Optional[datetime],
+    to_time: Optional[datetime],
+    span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]],
+    resource_attributes: Optional[util.AttributesFilter],
+    scope_attributes: Optional[util.AttributesFilter],
+    span_attributes: Optional[util.AttributesFilter],
+    span_name: Optional[str],
 ) -> base.ReifiedSpanCollection:
     spans.resource_spans = [
         _filter_resource_span_collection(
@@ -155,6 +171,7 @@ def _filter_span_collection(
             span_ids,
             scope_attributes,
             span_attributes,
+            span_name,
         )
         for inner_spans in spans.resource_spans
         if util.match_attributes(
@@ -179,9 +196,10 @@ class MockProxy(Proxy):
         from_time: Optional[datetime] = None,
         to_time: Optional[datetime] = None,
         span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-        resource_attributes: Optional[dict[str, list[str]]] = None,
-        scope_attributes: Optional[dict[str, list[str]]] = None,
-        span_attributes: Optional[dict[str, list[str]]] = None,
+        resource_attributes: Optional[util.AttributesFilter] = None,
+        scope_attributes: Optional[util.AttributesFilter] = None,
+        span_attributes: Optional[util.AttributesFilter] = None,
+        span_name: Optional[str] = None,
         page_token: Optional[PageToken] = None,
     ) -> AsyncIterable[base.SpanCollection | PageToken]:
         if page_token is not None:
@@ -203,4 +221,9 @@ class MockProxy(Proxy):
             resource_attributes,
             scope_attributes,
             span_attributes,
+            span_name,
         )
+
+    @override
+    async def aclose(self) -> None:
+        pass

--- a/src/python_opentelemetry_access/proxy/__init__.py
+++ b/src/python_opentelemetry_access/proxy/__init__.py
@@ -73,7 +73,7 @@ class Proxy(ABC):
         span_name: Optional[str],
         span_attributes: Optional[util.AttributesFilter],
         max_data_age: timedelta,
-    ) -> AsyncIterable[util.CheckData]:
+    ) -> AsyncIterable[base.ReifiedSpan]:
         now = datetime.now()
         async for spanCollection in self.query_spans_async(
             from_time=now - max_data_age,
@@ -82,35 +82,16 @@ class Proxy(ABC):
             span_name=span_name,
         ):
             for _resource, _scope, span in spanCollection.iter_spans():
-                yield util.CheckData(
-                    span_duration=span.duration(),
-                    attributes=span.otlp_attributes,
-                )
+                yield span.to_reified()
 
     def load_span_data_sync(
         self,
         span_name: str | None,
         span_attributes: util.AttributesFilter | None,
         max_data_age: timedelta,
-    ) -> Iterable[util.CheckData]:
+    ) -> Iterable[base.ReifiedSpan]:
         return util.async_to_sync_iterable(
             self.load_span_data_async(span_name, span_attributes, max_data_age)
-        )
-
-    def load_data_from_fields_async(
-        self, data_fields: list[str], max_data_age: timedelta
-    ) -> AsyncIterable[util.CheckData]:
-        return self.load_span_data_async(
-            span_name=None,
-            span_attributes={field: None for field in data_fields},
-            max_data_age=max_data_age,
-        )
-
-    def load_data_from_fields_sync(
-        self, data_fields: list[str], max_data_age: timedelta
-    ) -> Iterable[util.CheckData]:
-        return util.async_to_sync_iterable(
-            self.load_data_from_fields_async(data_fields, max_data_age)
         )
 
     # Close connections, release resources and such

--- a/src/python_opentelemetry_access/proxy/opensearch/ss4o/__init__.py
+++ b/src/python_opentelemetry_access/proxy/opensearch/ss4o/__init__.py
@@ -63,13 +63,19 @@ class OpenSearchSS40Proxy(proxy.Proxy):
                     case []:
                         pass
                     case [value]:
-                        result.append(
-                            # {"term": {key_prefix + key: {"value": value}}}
-                            {"term": {key_prefix + key + ".keyword": {"value": value}}}
-                        )
+                        result.append({"match": {key_prefix + key: value}})
                     case list(values):
                         result.append(
-                            {"terms": {key_prefix + key + ".keyword": values}}
+                            {
+                                "bool": {
+                                    # should acts as an OR here, as explained in
+                                    # https://discuss.elastic.co/t/how-do-i-create-a-boolean-or-filter/282281
+                                    "should": [
+                                        {"match": {key_prefix + key: value}}
+                                        for value in values
+                                    ]
+                                }
+                            }
                         )
                     case unreachable:
                         assert_never(unreachable)

--- a/src/python_opentelemetry_access/proxy/opensearch/ss4o/__init__.py
+++ b/src/python_opentelemetry_access/proxy/opensearch/ss4o/__init__.py
@@ -1,9 +1,10 @@
 import opensearchpy
 from collections.abc import AsyncIterable
-from typing import List, Optional, Tuple, override
+from typing import List, Optional, Tuple, override, assert_never
 from datetime import datetime
 from opensearchpy import AsyncOpenSearch
 
+from python_opentelemetry_access import util
 from python_opentelemetry_access.api_utils.exceptions import APIException
 from python_opentelemetry_access.api_utils.json_api_types import Error
 
@@ -25,9 +26,10 @@ class OpenSearchSS40Proxy(proxy.Proxy):
         from_time: Optional[datetime] = None,
         to_time: Optional[datetime] = None,
         span_ids: Optional[List[Tuple[Optional[str], Optional[str]]]] = None,
-        resource_attributes: Optional[dict[str, list[str]]] = None,
-        scope_attributes: Optional[dict[str, list[str]]] = None,
-        span_attributes: Optional[dict[str, list[str]]] = None,
+        resource_attributes: Optional[util.AttributesFilter] = None,
+        scope_attributes: Optional[util.AttributesFilter] = None,
+        span_attributes: Optional[util.AttributesFilter] = None,
+        span_name: Optional[str] = None,
         page_token: Optional[proxy.PageToken] = None,
     ) -> AsyncIterable[base.SpanCollection | proxy.PageToken]:
         filter: list[object] = []
@@ -51,21 +53,26 @@ class OpenSearchSS40Proxy(proxy.Proxy):
                 filter.append({"match": {"spanId": span_id}})
 
         def attributes_to_filters(
-            attributes: dict[str, list[str]], key_prefix: str
+            attributes: util.AttributesFilter, key_prefix: str
         ) -> list[object]:
             result: list[object] = []
             for key, values in attributes.items():
                 match values:
+                    case None:
+                        result.append({"exists": {"field": key_prefix + key}})
                     case []:
                         pass
                     case [value]:
                         result.append(
+                            # {"term": {key_prefix + key: {"value": value}}}
                             {"term": {key_prefix + key + ".keyword": {"value": value}}}
                         )
-                    case values:
+                    case list(values):
                         result.append(
                             {"terms": {key_prefix + key + ".keyword": values}}
                         )
+                    case unreachable:
+                        assert_never(unreachable)
             return result
 
         if resource_attributes is not None:
@@ -78,6 +85,9 @@ class OpenSearchSS40Proxy(proxy.Proxy):
 
         if span_attributes is not None:
             filter.extend(attributes_to_filters(span_attributes, "attributes."))
+
+        if span_name is not None:
+            filter.append({"term": {"name.keyword": {"value": span_name}}})
 
         q = {
             "size": self.page_size,
@@ -156,3 +166,7 @@ class OpenSearchSS40Proxy(proxy.Proxy):
 
         if next_page_token is not None:
             yield proxy.PageToken(next_page_token)
+
+    @override
+    async def aclose(self) -> None:
+        await self.client.close()

--- a/src/python_opentelemetry_access/util/__init__.py
+++ b/src/python_opentelemetry_access/util/__init__.py
@@ -366,8 +366,17 @@ def normalise_attributes_deep(jobj: JSONLikeDict) -> JSONLikeDict:
     )
 
 
+# IT's unclear to me if should represent key existence request with value None of with empty list
+# I'm leaning towards value None. It then becomes a question how we deal with the case where user specifies
+# key "foo" must exist, and another condition is "foo=5". I guess it just means "foo=5"?
+type AttributesFilter = dict[str, Optional[list[str]]]
+"""If some key is None, that means the key must exist, and the value can be anything"""
+
+
 def match_attributes(
-    actual_attributes: JSONLikeDict, expected_attributes: Optional[dict[str, list[str]]]
+    actual_attributes: JSONLikeDict,
+    # spell out the type to avoid circular imports
+    expected_attributes: Optional[AttributesFilter],
 ) -> bool:
     if expected_attributes is None:
         return True
@@ -378,7 +387,7 @@ def match_attributes(
     return all(
         (
             k in normalized_attributes
-            and str(expect_literal(normalized_attributes[k])) in vs
+            and (vs is None or str(expect_literal(normalized_attributes[k])) in vs)
         )
         for k, vs in expected_attributes.items()
     )

--- a/src/python_opentelemetry_access/util/__init__.py
+++ b/src/python_opentelemetry_access/util/__init__.py
@@ -1,5 +1,21 @@
+import asyncio
 from collections.abc import Iterator
-from typing import Optional, Self, Tuple, TypeVar, List, Union, Dict, Generic, override
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import (
+    Any,
+    AsyncIterable,
+    Iterable,
+    Optional,
+    Self,
+    Tuple,
+    TypeVar,
+    List,
+    Union,
+    Dict,
+    Generic,
+    override,
+)
 from itertools import chain, groupby
 
 import opentelemetry_betterproto.opentelemetry.proto.common.v1 as common
@@ -391,3 +407,25 @@ def match_attributes(
         )
         for k, vs in expected_attributes.items()
     )
+
+
+@dataclass
+class CheckData:
+    span_duration: timedelta
+    attributes: dict[str, Any]
+
+
+async def _async_list[T](
+    async_iterable: AsyncIterable[T],
+) -> Iterable[T]:
+    # TODO: would be nice to return the values as they become available, not accumulate them all first
+    results: list[T] = []
+    async for data in async_iterable:
+        results.append(data)
+    return results
+
+
+def async_to_sync_iterable[T](
+    async_iterable: AsyncIterable[T],
+) -> Iterable[T]:
+    return asyncio.run(_async_list(async_iterable))

--- a/src/python_opentelemetry_access/util/__init__.py
+++ b/src/python_opentelemetry_access/util/__init__.py
@@ -133,7 +133,18 @@ def to_otlp_any_value_iter(jval: JSONLikeIter) -> JSONLikeDictIter:
                 [
                     (
                         "arrayValue",
-                        JSONLikeListIter((to_otlp_any_value_iter(x) for x in jval)),
+                        JSONLikeDictIter(
+                            iter(
+                                [
+                                    (
+                                        "values",
+                                        JSONLikeListIter(
+                                            (to_otlp_any_value_iter(x) for x in jval)
+                                        ),
+                                    )
+                                ]
+                            )
+                        ),
                     )
                 ]
             )

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -12,14 +12,35 @@ class Params:
     from_time: datetime | None = None
     to_time: datetime | None = None
     span_ids: list[tuple[str | None, str | None]] | None = None
-    resource_attributes: dict[str, list[str]] | None = None
-    scope_attributes: dict[str, list[str]] | None = None
-    span_attributes: dict[str, list[str]] | None = None
+    resource_attributes: util.AttributesFilter | None = None
+    scope_attributes: util.AttributesFilter | None = None
+    span_attributes: util.AttributesFilter | None = None
+    span_name: str | None = None
 
 
 @mark.parametrize(
     "params",
     [
+        Params(
+            expected_spans=["res1_scope1_trace1_span1", "res1_scope2_trace1_span1"],
+            span_name="some_span1",
+        ),
+        Params(
+            expected_spans=["res1_scope1_trace1_span1", "res1_scope2_trace1_span1"],
+            resource_attributes={
+                "int_resource_attr": ["100"],
+                "string_resource_attr": None,
+            },
+            span_attributes={"string_span_attr": ["span string 1"]},
+        ),
+        Params(
+            expected_spans=[],
+            resource_attributes={
+                "int_resource_attr": ["100"],
+                "string_resource_attr_typo": None,
+            },
+            span_attributes={"string_span_attr": ["span string 1"]},
+        ),
         Params(
             expected_spans=["res1_scope1_trace1_span1", "res1_scope2_trace1_span1"],
             resource_attributes={"int_resource_attr": ["100"]},
@@ -56,6 +77,7 @@ def test_filtering(params: Params) -> None:
         resource_attributes=params.resource_attributes,
         scope_attributes=params.scope_attributes,
         span_attributes=params.span_attributes,
+        span_name=params.span_name,
     )
 
     span_ids = set(
@@ -99,7 +121,7 @@ def _get_spans() -> util.JSONLike:
                                 "parentSpanId": "",
                                 "startTimeUnixNano": "1729007194857023153",
                                 "endTimeUnixNano": "1729007194857127603",
-                                "name": "some_span",
+                                "name": "some_span1",
                                 "kind": 1,
                                 "status": {},
                                 "attributes": [
@@ -119,7 +141,7 @@ def _get_spans() -> util.JSONLike:
                                 "parentSpanId": "res1_scope1_trace1_span1",
                                 "startTimeUnixNano": "1729007194857023153",
                                 "endTimeUnixNano": "1729007194857127603",
-                                "name": "some_span",
+                                "name": "some_span2",
                                 "kind": 1,
                                 "status": {},
                                 "attributes": [
@@ -153,7 +175,7 @@ def _get_spans() -> util.JSONLike:
                                 "parentSpanId": "",
                                 "startTimeUnixNano": "1729007194857023153",
                                 "endTimeUnixNano": "1729007194857127603",
-                                "name": "some_span",
+                                "name": "some_span1",
                                 "kind": 1,
                                 "status": {},
                                 "attributes": [
@@ -173,7 +195,7 @@ def _get_spans() -> util.JSONLike:
                                 "parentSpanId": "res1_scope2_trace1_span1",
                                 "startTimeUnixNano": "1729007194857023153",
                                 "endTimeUnixNano": "1729007194857127603",
-                                "name": "some_span",
+                                "name": "some_span2",
                                 "kind": 1,
                                 "status": {},
                                 "attributes": [
@@ -220,7 +242,7 @@ def _get_spans() -> util.JSONLike:
                                 "parentSpanId": "",
                                 "startTimeUnixNano": "1729007194857023153",
                                 "endTimeUnixNano": "1729007194857127603",
-                                "name": "some_span",
+                                "name": "some_span3",
                                 "kind": 1,
                                 "status": {},
                                 "attributes": [

--- a/tests/test_otlp_json.py
+++ b/tests/test_otlp_json.py
@@ -12,7 +12,9 @@ def test_roundtrip_complete_json():
         {"key": "foo", "value": {"doubleValue": 3.2}},
         {
             "key": "other",
-            "value": {"arrayValue": [{"stringValue": "bar"}, {"intValue": "2"}]},
+            "value": {
+                "arrayValue": {"values": [{"stringValue": "bar"}, {"intValue": "2"}]}
+            },
         },
         {
             "key": "stuff",

--- a/tests/test_reified.py
+++ b/tests/test_reified.py
@@ -11,7 +11,9 @@ def test_roundtrip_complete_proto():
         {"key": "foo", "value": {"doubleValue": 3.2}},
         {
             "key": "other",
-            "value": {"arrayValue": [{"stringValue": "bar"}, {"intValue": "2"}]},
+            "value": {
+                "arrayValue": {"values": [{"stringValue": "bar"}, {"intValue": "2"}]}
+            },
         },
         {
             "key": "stuff",


### PR DESCRIPTION
Adds example checks which consume data from previous checks, and also the telemetry filtering updates necessary to support that